### PR TITLE
Fix server file browser to start in /data instead of /root

### DIFF
--- a/app/api/browse-files/route.js
+++ b/app/api/browse-files/route.js
@@ -12,9 +12,16 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     let dirPath = searchParams.get('path');
     
-    // If no path provided, use home directory
+    // If no path provided, use /data or root directory (/)
+    // Avoid using os.homedir() which may be /root (inaccessible to node user)
     if (!dirPath) {
-      dirPath = os.homedir();
+      // Try /data first (where volumes are mounted), fall back to root
+      try {
+        await fs.access('/data', fs.constants.R_OK);
+        dirPath = '/data';
+      } catch {
+        dirPath = '/';
+      }
     }
     
     // Expand tilde if present


### PR DESCRIPTION
The YAML Utility server browser was starting in the /root directory causing permission issues.  Corrected to 

1. Start in /data by default (where your volume-mounted config files are)
2. Fall back to / (root filesystem) if /data isn't accessible
3. Never use /root (which the node user can't access)