### PR TITLE
Adding unix socket to supervisord for healthcheck

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,3 +1,10 @@
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
 [supervisord]
 nodaemon=true
 user=root


### PR DESCRIPTION
The problem was that [supervisord.conf](vscode-file://vscode-app/c:/Users/dscho/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/7f08f95ad5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was missing the [unix_http_server] and [supervisorctl] sections that allow supervisorctl to communicate with supervisord via a unix socket.