### PR TITLE
Another Attempt at supervisord running, adding the [rpcinterface:supervisor] section

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,9 +1,12 @@
 [unix_http_server]
 file=/tmp/supervisor.sock
-chmod=0700
+chmod=0766
 
 [supervisorctl]
 serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisord]
 nodaemon=true


### PR DESCRIPTION
The HEALTHCHECK runs as root, but the socket might have a user permission issue. Let me check what the actual socket permissions error might be. Let's add the [rpcinterface:supervisor] section which is required for supervisorctl to work.