### PR TITLE
Remove automatic trigger when docker image is created from main merges

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+      # - main
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Was running two builds, when a push with tag to branch and main when pull request merged branch with main