### PR TITLE
Fix: Remove redundant download button from MonacoYamlViewer and impro…

### DIFF
--- a/src/components/DownloadFilesModal.jsx
+++ b/src/components/DownloadFilesModal.jsx
@@ -81,6 +81,7 @@ const DownloadFilesModal = ({ files, isOpen, onClose }) => {
           }
         } else {
           // Fallback to standard download (one by one to downloads folder)
+          setError('Note: Folder selection not available. Files will be downloaded to your browser\'s default Downloads folder. File System Access API is not supported in this browser/environment.');
           for (const index of selectedFiles) {
             const file = files[index];
             const blob = new Blob([file.content], { type: 'text/yaml' });
@@ -95,7 +96,9 @@ const DownloadFilesModal = ({ files, isOpen, onClose }) => {
             // Small delay between downloads
             await new Promise(resolve => setTimeout(resolve, 100));
           }
-          onClose();
+          // Don't close immediately so user sees the message
+          setDownloading(false);
+          return;
         }
       } else {
         // Save to server

--- a/src/components/MonacoYamlViewer.jsx
+++ b/src/components/MonacoYamlViewer.jsx
@@ -12,7 +12,6 @@ const MonacoYamlViewer = ({
   lastModified = null,
   showFileInfo = true,
   showActions = true,
-  onDownload = null,
   onCopy = null,
   onEdit = null,
   className = '',
@@ -35,22 +34,6 @@ const MonacoYamlViewer = ({
     
     // Focus the editor
     editor.focus();
-  };
-
-  const handleDownload = () => {
-    if (onDownload) {
-      onDownload();
-    } else {
-      const blob = new Blob([fileContent], { type: 'text/yaml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = fileName;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
   };
 
   const handleCopy = async () => {
@@ -175,30 +158,18 @@ const MonacoYamlViewer = ({
                 <Icon fontSize={{ base: "xs", sm: "md" }}><MdContentCopy /></Icon>
                 <Text display={{ base: "none", sm: "inline" }} ml={1}>Copy</Text>
               </Button>
+              {onEdit && (
               <Button 
-                onClick={handleDownload} 
+                onClick={onEdit} 
                 variant="outline" 
                 size={{ base: "xs", sm: "sm" }} 
                 colorPalette="gray"
-                title="Download file"
+                title="Edit file"
                 fontSize={{ base: "2xs", sm: "sm" }}
                 px={{ base: 1.5, sm: 3 }}
                 h={{ base: "24px", sm: "auto" }}
               >
-                <Icon fontSize={{ base: "xs", sm: "md" }}><MdDownload /></Icon>
-                <Text display={{ base: "none", sm: "inline" }} ml={1}>Download</Text>
-              </Button>
-              {onEdit && (
-                <Button 
-                  onClick={onEdit} 
-                  variant="outline" 
-                  size={{ base: "xs", sm: "sm" }} 
-                  colorPalette="gray"
-                  title="Edit file"
-                  fontSize={{ base: "2xs", sm: "sm" }}
-                  px={{ base: 1.5, sm: 3 }}
-                  h={{ base: "24px", sm: "auto" }}
-                >
+
                   <Icon fontSize={{ base: "xs", sm: "md" }}><MdEdit /></Icon>
                   <Text display={{ base: "none", sm: "inline" }} ml={1}>Edit</Text>
                 </Button>

--- a/src/components/YamlViewer.jsx
+++ b/src/components/YamlViewer.jsx
@@ -211,7 +211,7 @@ const YamlViewer = ({ files, onClose, onClearFiles, onLoadMoreFiles, onFilesUpda
             minW={{ base: "auto", sm: "auto" }}
           >
             <Icon fontSize={{ base: "xs", sm: "sm" }}><MdDownload /></Icon>
-            <Text ml={0.5} display={{ base: "none", sm: "inline" }}>Download All</Text>
+            <Text ml={0.5} display={{ base: "none", sm: "inline" }}>Download</Text>
           </Button>
           <Button
             onClick={() => setShowSplitModal(true)}


### PR DESCRIPTION
…ve File System Access API messaging

- Removed download button from MonacoYamlViewer since comprehensive download functionality now exists in YamlViewer toolbar
- Added informative error message when File System Access API is not available (e.g., on Linux or unsupported browsers)
- Fixed CombineFilesModal lint errors: removed duplicate _dark JSX attribute and moved setState calls out of useMemo
- Updated button text from 'Download All' to 'Download' for consistency