### PR TITLE
Feature: Add global sports list context with auto-refresh

### DIFF
--- a/src/components/Providers.jsx
+++ b/src/components/Providers.jsx
@@ -3,12 +3,15 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { ThemeProvider } from 'next-themes';
 import { system } from '../theme';
+import { SportsListProvider } from '../contexts/SportsListContext';
 
 export function Providers({ children }) {
   return (
     <ChakraProvider value={system}>
       <ThemeProvider attribute="class" disableTransitionOnChange>
-        {children}
+        <SportsListProvider>
+          {children}
+        </SportsListProvider>
       </ThemeProvider>
     </ChakraProvider>
   );

--- a/src/components/SportsListEditor.jsx
+++ b/src/components/SportsListEditor.jsx
@@ -3,8 +3,10 @@ import { Box, VStack, HStack, Flex, Heading, Text, Button, Input, Icon, IconButt
 import { MdExpandMore, MdChevronRight, MdAdd, MdDelete, MdEdit, MdSave } from 'react-icons/md';
 import { readSportsList, writeSportsList, initialSportsList } from '../utils/sportsListManager';
 import { ConfirmDialog } from './ConfirmDialog';
+import { useSportsList } from '../contexts/SportsListContext';
 
 export default function SportsListEditor({ settings, onDirtyChange }) {
+  const { loadSportsList } = useSportsList();
   const [sportsList, setSportsList] = useState(initialSportsList);
   const [initialSnapshot, setInitialSnapshot] = useState(() => JSON.stringify(initialSportsList));
   const [expandedCategories, setExpandedCategories] = useState({});
@@ -180,6 +182,8 @@ export default function SportsListEditor({ settings, onDirtyChange }) {
   const handleSave = async () => {
     try {
       await writeSportsList(settings, sportsList);
+      // Refresh the global sports list context so all components see the updated list
+      await loadSportsList();
       const snapshot = JSON.stringify(sportsList);
       setInitialSnapshot(snapshot);
       setIsDirty(false);

--- a/src/components/config/ImportConfigEditor.jsx
+++ b/src/components/config/ImportConfigEditor.jsx
@@ -21,7 +21,7 @@ import { MdAdd, MdClose, MdWarning, MdInfo, MdLightbulb } from 'react-icons/md';
 import BaseConfigEditor from './BaseConfigEditor';
 import { Tooltip } from '../Tooltip';
 import { generateRandomString } from '../../utils/stringUtils';
-import { initialSportsList } from '../../utils/sportsListManager';
+import { useSportsList } from '../../contexts/SportsListContext';
 import SportTypeMultiSelect from './appearance/SportTypeMultiSelect';
 
 /**
@@ -35,6 +35,7 @@ const ImportConfigEditor = ({
   isLoading,
   onDirtyChange 
 }) => {
+  const { sportsList } = useSportsList();
   // State for array field inputs
   const [arrayInputs, setArrayInputs] = useState({
     activitiesToSkipDuringImport: ''
@@ -261,7 +262,7 @@ const ImportConfigEditor = ({
                 value={value}
                 onChange={handleFieldChange}
                 hasError={errors[fieldName]}
-                sportsList={initialSportsList}
+                sportsList={sportsList}
                 subsectionKey="import"
               />
               

--- a/src/components/config/MetricsConfigEditor.jsx
+++ b/src/components/config/MetricsConfigEditor.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Box,
   VStack,
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react';
 import { MdAdd, MdDelete, MdArrowUpward, MdArrowDownward, MdExpandMore, MdChevronRight, MdInfo, MdWarning } from 'react-icons/md';
 import BaseConfigEditor from './BaseConfigEditor';
-import { readSportsList, initialSportsList } from '../../utils/sportsListManager';
+import { useSportsList } from '../../contexts/SportsListContext';
 
 /**
  * MetricsConfigEditor - Handles metrics configuration fields
@@ -31,22 +31,8 @@ const MetricsConfigEditor = ({
   isLoading,
   onDirtyChange 
 }) => {
-  const [sportsList, setSportsList] = useState(initialSportsList);
+  const { sportsList } = useSportsList();
   const [expandedEddington, setExpandedEddington] = useState({});
-
-  // Load sports list for sport type selection
-  useEffect(() => {
-    async function loadSports() {
-      try {
-        const settings = JSON.parse(localStorage.getItem('config-tool-settings') || '{}');
-        const list = await readSportsList(settings);
-        setSportsList(list);
-      } catch (error) {
-        console.error('Error loading sports list:', error);
-      }
-    }
-    loadSports();
-  }, []);
 
   // Custom validation for metrics fields
   const validateMetricsFields = (formData, getNestedValue) => {

--- a/src/components/config/appearance/useAppearanceConfig.js
+++ b/src/components/config/appearance/useAppearanceConfig.js
@@ -1,37 +1,11 @@
-import { useState, useEffect } from 'react';
-import { readSportsList, initialSportsList } from '../../../utils/sportsListManager';
+import { useSportsList } from '../../../contexts/SportsListContext';
 
 /**
  * Custom hook for appearance configuration logic
  * Handles sports list loading and appearance-specific validation
  */
 export const useAppearanceConfig = () => {
-  const [sportsList, setSportsList] = useState(initialSportsList);
-
-  // Load sports list for sport type selection
-  useEffect(() => {
-    async function loadSports() {
-      try {
-        const settings = JSON.parse(localStorage.getItem('config-tool-settings') || '{}');
-        const list = await readSportsList(settings);
-        setSportsList(list);
-      } catch (error) {
-        console.error('Error loading sports list:', error);
-      }
-    }
-    loadSports();
-  }, []);
-
-  // Get flat array of all sport types
-  const getAllSportTypes = () => {
-    const allSports = [];
-    Object.values(sportsList).forEach(categoryArray => {
-      if (Array.isArray(categoryArray)) {
-        allSports.push(...categoryArray);
-      }
-    });
-    return allSports;
-  };
+  const { sportsList, getAllSportTypes } = useSportsList();
 
   // Custom validation for appearance fields
   const validateAppearanceFields = (formData, getNestedValue) => {

--- a/src/contexts/SportsListContext.jsx
+++ b/src/contexts/SportsListContext.jsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { readSportsList, initialSportsList } from '../utils/sportsListManager';
+
+const SportsListContext = createContext();
+
+export const useSportsList = () => {
+  const context = useContext(SportsListContext);
+  if (!context) {
+    throw new Error('useSportsList must be used within a SportsListProvider');
+  }
+  return context;
+};
+
+export const SportsListProvider = ({ children }) => {
+  const [sportsList, setSportsList] = useState(initialSportsList);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadSportsList = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const settings = JSON.parse(localStorage.getItem('config-tool-settings') || '{}');
+      const list = await readSportsList(settings);
+      setSportsList(list);
+    } catch (error) {
+      console.error('Error loading sports list:', error);
+      setSportsList(initialSportsList);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Load sports list on mount
+  useEffect(() => {
+    loadSportsList();
+  }, [loadSportsList]);
+
+  // Get flat array of all sport types
+  const getAllSportTypes = useCallback(() => {
+    const allSports = [];
+    Object.values(sportsList).forEach(categoryArray => {
+      if (Array.isArray(categoryArray)) {
+        allSports.push(...categoryArray);
+      }
+    });
+    return allSports;
+  }, [sportsList]);
+
+  const value = {
+    sportsList,
+    isLoading,
+    loadSportsList,
+    getAllSportTypes
+  };
+
+  return (
+    <SportsListContext.Provider value={value}>
+      {children}
+    </SportsListContext.Provider>
+  );
+};


### PR DESCRIPTION
- Create SportsListContext to manage sports list state globally
- All config editors (Appearance, Metrics, Import) now subscribe to shared context
- SportsListEditor calls loadSportsList() after saving to refresh all subscribers
- Removes duplicate sports list loading across components
- Config editors now immediately reflect changes made in Settings -> Sports List