### PR TITLE
Fix: Normalize path separators for cross-platform compatibility

### DIFF
--- a/src/components/DownloadFilesModal.jsx
+++ b/src/components/DownloadFilesModal.jsx
@@ -109,8 +109,8 @@ const DownloadFilesModal = ({ files, isOpen, onClose }) => {
         for (const index of selectedFiles) {
           const file = files[index];
           
-          // Construct full file path
-          const cleanPath = savePath.replace(/\/$/, '');
+          // Construct full file path (normalize for cross-platform compatibility)
+          const cleanPath = savePath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
           const fullPath = `${cleanPath}/${file.name}`;
           
           const response = await fetch('/api/save-file', {

--- a/src/utils/settingsManager.js
+++ b/src/utils/settingsManager.js
@@ -42,8 +42,8 @@ const DEFAULT_SETTINGS = {
  */
 export const getSettingsFilePath = (defaultPath = null) => {
   const basePath = defaultPath || DEFAULT_SETTINGS_PATH;
-  // Remove trailing slash if present
-  const cleanPath = basePath.replace(/\/$/, '');
+  // Remove trailing slash/backslash if present and normalize to forward slashes
+  const cleanPath = basePath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
   return `${cleanPath}/settings/${SETTINGS_FILENAME}`;
 };
 

--- a/src/utils/sportsListInitializer.js
+++ b/src/utils/sportsListInitializer.js
@@ -48,10 +48,9 @@ export const initialSportsList = {
  */
 function getSportsListPath() {
   const defaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
-  const normalizedPath = defaultPath.endsWith('/') || defaultPath.endsWith('\\') 
-    ? defaultPath 
-    : defaultPath + '/';
-  return normalizedPath + 'settings/strava-sports-by-category.yaml';
+  // Remove trailing slashes and normalize to forward slashes for cross-platform compatibility
+  const normalizedPath = defaultPath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
+  return normalizedPath + '/settings/strava-sports-by-category.yaml';
 }
 
 /**

--- a/src/utils/widgetDefinitionsInitializer.js
+++ b/src/utils/widgetDefinitionsInitializer.js
@@ -16,9 +16,8 @@ import { getSetting } from './settingsManager.js';
  */
 function getWidgetDefinitionsPath() {
   const defaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
-  const normalizedPath = defaultPath.endsWith('/') || defaultPath.endsWith('\\') 
-    ? defaultPath 
-    : defaultPath + '/';
+  // Remove trailing slashes and normalize to forward slashes for cross-platform compatibility
+  const normalizedPath = defaultPath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
   return normalizedPath + 'settings/widget-definitions.yaml';
 }
 

--- a/src/utils/widgetDefinitionsManager.js
+++ b/src/utils/widgetDefinitionsManager.js
@@ -14,11 +14,9 @@ const WIDGET_DEFINITIONS_FILENAME = 'widget-definitions.yaml';
  */
 function getWidgetDefinitionsPath() {
   const defaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
-  // Ensure path ends with a separator
-  const normalizedPath = defaultPath.endsWith('/') || defaultPath.endsWith('\\') 
-    ? defaultPath 
-    : defaultPath + '/';
-  return normalizedPath + 'settings/' + WIDGET_DEFINITIONS_FILENAME;
+  // Remove trailing slashes and normalize to forward slashes for cross-platform compatibility
+  const normalizedPath = defaultPath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
+  return normalizedPath + '/settings/' + WIDGET_DEFINITIONS_FILENAME;
 }
 
 /**


### PR DESCRIPTION
- Remove trailing slashes/backslashes consistently across all utilities
- Normalize backslashes to forward slashes for Windows/Linux compatibility
- Fix mixed path separator issue (e.g., C:\path\\/settings/)
- Update settingsManager, sportsListInitializer, widgetDefinitionsManager, widgetDefinitionsInitializer, and DownloadFilesModal
- Forward slashes work on all platforms thanks to Node.js path handling