### PR TITLE
Fix: Remove unused imports and correct path construction

### DIFF
--- a/src/utils/sportsListManager.js
+++ b/src/utils/sportsListManager.js
@@ -1,4 +1,3 @@
-import { getSportsList, saveSportsList } from './apiClient';
 import { initialSportsList } from './sportsListInitializer';
 
 // initialSportsList is now imported from sportsListInitializer.js to maintain single source of truth

--- a/src/utils/widgetDefinitionsInitializer.js
+++ b/src/utils/widgetDefinitionsInitializer.js
@@ -18,7 +18,7 @@ function getWidgetDefinitionsPath() {
   const defaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
   // Remove trailing slashes and normalize to forward slashes for cross-platform compatibility
   const normalizedPath = defaultPath.replace(/[\\/]+$/, '').replace(/\\/g, '/');
-  return normalizedPath + 'settings/widget-definitions.yaml';
+  return normalizedPath + '/settings/widget-definitions.yaml';
 }
 
 /**


### PR DESCRIPTION
- Remove unused getSportsList and saveSportsList imports from sportsListManager
- Add missing leading slash in widgetDefinitionsInitializer path construction
- Fixes 404 error for widget-definitions.yaml (was 'configsettings' instead of 'config/settings')