### PR TITLE
fix: exclude gear-maintenance files from section mapping in AppShell

### DIFF
--- a/app/_components/layout/AppShell.jsx
+++ b/app/_components/layout/AppShell.jsx
@@ -81,8 +81,9 @@ export default function AppShell({ section = 'config', children }) {
             directory: result.directory
           });
 
-          // Parse sections to build mapping
-          const parseResult = await parseSectionsService(result.files);
+          // Parse sections to build mapping (exclude gear-maintenance files)
+          const filesToParse = result.files.filter(file => !file.isGearMaintenance);
+          const parseResult = await parseSectionsService(filesToParse);
           if (parseResult.success) {
             const mappingToUse = parseResult.detailedMapping || parseResult.sectionMapping;
             const newMapping = new Map(Object.entries(mappingToUse));


### PR DESCRIPTION
AppShell initialization path was missing the filter to exclude gear-maintenance.yaml files before calling parseSections, causing gear-maintenance top-level keys to appear in section mappings.

This completes the fix started in previous commit by adding the same filter (file => !file.isGearMaintenance) used in ConfigFileList.