### PR TITLE
fix: restore has Comments variable definition

### DIFF
--- a/app/api/update-section/route.js
+++ b/app/api/update-section/route.js
@@ -524,7 +524,8 @@ export async function POST(request) {
     await fs.writeFile(filePath, updatedYaml, 'utf8');
 
     // Debug: Check if comments were preserved
-    debugLog('Comments preserved:', updatedYaml.includes('#'));
+    const hasComments = updatedYaml.includes('#');
+    debugLog('Comments preserved:', hasComments);
     debugLog('Updated YAML preview:', updatedYaml.substring(0, 200) + '...');
 
     return NextResponse.json({


### PR DESCRIPTION
Variable was accidentally removed during debug cleanup but is still used in the API response. Now properly defines hasComments before using it in the debug response object.

Fixes ReferenceError: hasComments is not defined when saving config.