### PR TITLE
fix: prevent general section from deleting athlete subsection

### DIFF
--- a/app/(config)/_components/ConfigFileList.jsx
+++ b/app/(config)/_components/ConfigFileList.jsx
@@ -62,7 +62,13 @@ const ConfigFileList = forwardRef((props, ref) => {
         setMissingSections(result.missingSections || []);
 
         if (!result.isComplete) {
-          showWarning(`Configuration incomplete: ${result.missingSections.length} section(s) missing`);
+          const missingCount = (result.missingSections?.length || 0) + (result.missingSubsections?.length || 0);
+          const missingItems = [
+            ...(result.missingSections || []),
+            ...(result.missingSubsections?.map(s => `${s} (subsection)`) || [])
+          ].join(', ');
+          
+          showWarning(`Configuration incomplete: ${missingCount} section(s) missing - ${missingItems}`);
         }
       }
     } catch (error) {

--- a/src/hooks/useConfigData.js
+++ b/src/hooks/useConfigData.js
@@ -383,12 +383,22 @@ export const useConfigData = (fileCache, sectionToFileMap, showError, showSucces
         filePath = sectionInfo.filePath;
       }
       
+      // Define nested keys that should be preserved during save (even if not split files)
+      // This handles cases where a section has nested subsections that are edited separately
+      const NESTED_KEYS_TO_PRESERVE = {
+        general: ['athlete'], // athlete is edited on separate page but stored under general
+        // Add other sections here if they have similar patterns in the future
+      };
+      
+      const preserveNestedKeys = NESTED_KEYS_TO_PRESERVE[sectionKey] || [];
+      
       if (filePath) {
         const result = await updateSection({
           filePath,
           sectionName: sectionName.toLowerCase(),
           sectionData: data,
-          isAthlete: sectionName.toLowerCase() === 'athlete'
+          isAthlete: sectionName.toLowerCase() === 'athlete',
+          preserveNestedKeys
         });
         
         if (result.success) {


### PR DESCRIPTION
- Add NESTED_KEYS_TO_PRESERVE map in useConfigData to preserve athlete when saving general
- Pass preserveNestedKeys parameter to updateSection for general section
- Add REQUIRED_SUBSECTION_MAPPINGS validation for athlete mapping detection
- Update validate-sections API to check for missing subsections
- Enhance ConfigFileList to display warnings about missing subsections
- Fixes issue where editing general fields (appUrl, appSubTitle, profilePictureUrl) deleted entire athlete section (birthday, heartRateZones, ftpHistory, weightHistory)