### PR TITLE
Add SFS Console command discovery, streaming improvements, and timeout fixes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,10 @@
       "Bash(cat:*)",
       "Bash(dir:*)",
       "Bash(npm install:*)",
-      "Bash(npm run lint:*)"
+      "Bash(npm run lint:*)",
+      "Bash(git status:*)",
+      "Bash(git checkout:*)",
+      "Bash(if not exist \"e:\\\\Strava-Project\\\\stats-for-strava-config-tool\\\\app\\\\api\\\\strava-console\\\\discover\" mkdir \"e:\\\\Strava-Project\\\\stats-for-strava-config-tool\\\\app\\\\api\\\\strava-console\\\\discover\")"
     ]
   }
 }

--- a/app/api/strava-console/discover/route.js
+++ b/app/api/strava-console/discover/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const STRAVA_RUNNER_URL = process.env.STRAVA_RUNNER_URL || 'http://strava-runner:8080';
+
+/**
+ * GET - Discover available Symfony commands from the target container
+ * Proxies to the runner's /discover endpoint
+ */
+export async function GET() {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 40000);
+
+    const response = await fetch(`${STRAVA_RUNNER_URL}/discover`, {
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      return NextResponse.json({
+        success: false,
+        error: 'Discovery request timed out'
+      }, { status: 504 });
+    }
+
+    return NextResponse.json({
+      success: false,
+      error: error.message
+    }, { status: 503 });
+  }
+}

--- a/app/api/strava-console/route.js
+++ b/app/api/strava-console/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
+export const maxDuration = 1800; // 30 minutes - support long-running Symfony commands
 
 // Runner URL - configurable via environment variable
 const STRAVA_RUNNER_URL = process.env.STRAVA_RUNNER_URL || 'http://strava-runner:8080';

--- a/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
+++ b/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Button,
+  Icon,
+  Badge,
+  Flex
+} from '@chakra-ui/react';
+import {
+  MdClose,
+  MdMerge,
+  MdSwapHoriz,
+  MdNewReleases,
+  MdWarning
+} from 'react-icons/md';
+
+/**
+ * Dialog component for displaying discovered commands from the Strava container.
+ * Allows users to merge new commands or replace all existing commands.
+ */
+export default function DiscoverCommandsDialog({
+  commands,
+  existingCommands,
+  onMerge,
+  onOverwrite,
+  onClose,
+  error
+}) {
+  const [confirmOverwrite, setConfirmOverwrite] = useState(false);
+
+  // Determine which commands are new vs existing
+  const { commandEntries, newCount, existingCount } = useMemo(() => {
+    const existingIds = new Set(existingCommands.map(cmd => cmd.id));
+    const entries = Object.entries(commands).map(([id, entry]) => ({
+      id,
+      name: entry.name || id,
+      description: entry.description || '',
+      isNew: !existingIds.has(id)
+    }));
+
+    const newOnes = entries.filter(e => e.isNew).length;
+    return {
+      commandEntries: entries,
+      newCount: newOnes,
+      existingCount: entries.length - newOnes
+    };
+  }, [commands, existingCommands]);
+
+  if (error) {
+    return (
+      <Box
+        p={5}
+        bg="cardBg"
+        borderRadius="lg"
+        border="1px solid"
+        borderColor="red.200"
+        _dark={{ borderColor: 'red.700' }}
+      >
+        <Flex justify="space-between" align="center" mb={3}>
+          <Text fontWeight="medium" color="red.600" _dark={{ color: 'red.300' }}>
+            Discovery Failed
+          </Text>
+          <Button size="xs" variant="ghost" onClick={onClose}>
+            <Icon as={MdClose} />
+          </Button>
+        </Flex>
+        <Text fontSize="sm" color="red.500" _dark={{ color: 'red.400' }}>
+          {error}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      p={5}
+      bg="cardBg"
+      borderRadius="lg"
+      border="1px solid"
+      borderColor="border"
+    >
+      {/* Header */}
+      <Flex justify="space-between" align="center" mb={4}>
+        <HStack gap={2}>
+          <Text fontWeight="semibold" color="text" fontSize="md">
+            Discovered Commands
+          </Text>
+          <Badge colorPalette="blue" variant="subtle" size="sm">
+            {commandEntries.length} found
+          </Badge>
+          {newCount > 0 && (
+            <Badge colorPalette="green" variant="subtle" size="sm">
+              {newCount} new
+            </Badge>
+          )}
+        </HStack>
+        <Button size="xs" variant="ghost" onClick={onClose} color="text">
+          <Icon as={MdClose} />
+        </Button>
+      </Flex>
+
+      {/* Command List */}
+      <Box
+        maxH="300px"
+        overflowY="auto"
+        mb={4}
+        borderRadius="md"
+        border="1px solid"
+        borderColor="border"
+      >
+        <VStack align="stretch" gap={0} divideY="1px" divideColor="border">
+          {commandEntries.map((entry) => (
+            <Flex
+              key={entry.id}
+              px={4}
+              py={3}
+              align="center"
+              gap={3}
+              bg={entry.isNew ? 'green.50' : 'transparent'}
+              _dark={{ bg: entry.isNew ? 'rgba(34, 197, 94, 0.05)' : 'transparent' }}
+            >
+              <Box flex="1" minW={0}>
+                <HStack gap={2} mb={1}>
+                  <Text fontSize="sm" fontWeight="medium" color="text" isTruncated>
+                    {entry.name}
+                  </Text>
+                  {entry.isNew && (
+                    <Badge colorPalette="green" variant="solid" size="xs">
+                      <HStack gap={1}>
+                        <Icon as={MdNewReleases} boxSize={3} />
+                        <Text>New</Text>
+                      </HStack>
+                    </Badge>
+                  )}
+                </HStack>
+                {entry.description && (
+                  <Text fontSize="xs" color="textMuted" isTruncated>
+                    {entry.description}
+                  </Text>
+                )}
+                <Text fontSize="xs" color="textMuted" fontFamily="mono" mt={0.5}>
+                  php bin/console {entry.id}
+                </Text>
+              </Box>
+            </Flex>
+          ))}
+        </VStack>
+      </Box>
+
+      {/* Summary */}
+      <Text fontSize="xs" color="textMuted" mb={4}>
+        {newCount > 0
+          ? `${newCount} new command${newCount > 1 ? 's' : ''} found, ${existingCount} already configured.`
+          : 'All discovered commands are already in your configuration.'}
+      </Text>
+
+      {/* Actions */}
+      {!confirmOverwrite ? (
+        <Flex gap={3} justify="flex-end" wrap="wrap">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            color="text"
+            borderColor="border"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            colorPalette="orange"
+            onClick={() => setConfirmOverwrite(true)}
+          >
+            <Icon as={MdSwapHoriz} mr={2} />
+            Replace All
+          </Button>
+          <Button
+            colorPalette="green"
+            size="sm"
+            onClick={() => onMerge(commands)}
+            disabled={newCount === 0}
+            title={newCount === 0 ? 'No new commands to merge' : `Add ${newCount} new command${newCount > 1 ? 's' : ''}`}
+          >
+            <Icon as={MdMerge} mr={2} />
+            Merge ({newCount} new)
+          </Button>
+        </Flex>
+      ) : (
+        <Box
+          p={3}
+          bg="orange.50"
+          _dark={{ bg: 'rgba(251, 146, 60, 0.1)' }}
+          borderRadius="md"
+          border="1px solid"
+          borderColor="orange.200"
+          _darkBorderColor="orange.700"
+        >
+          <Flex gap={2} align="center" mb={3}>
+            <Icon as={MdWarning} color="orange.500" boxSize={4} />
+            <Text fontSize="sm" fontWeight="medium" color="orange.700" _dark={{ color: 'orange.200' }}>
+              This will replace all existing commands with the {commandEntries.length} discovered commands.
+            </Text>
+          </Flex>
+          <Flex gap={2} justify="flex-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setConfirmOverwrite(false)}
+              color="text"
+              borderColor="border"
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              colorPalette="orange"
+              onClick={() => onOverwrite(commands)}
+            >
+              Confirm Replace All
+            </Button>
+          </Flex>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/StravaConsoleTerminal.jsx
+++ b/app/utilities/_components/strava-console/StravaConsoleTerminal.jsx
@@ -40,6 +40,11 @@ const StravaConsoleTerminal = forwardRef(function StravaConsoleTerminal({ onRead
       if (terminalRef.current) {
         terminalRef.current.focus();
       }
+    },
+    scrollToBottom: () => {
+      if (terminalRef.current) {
+        terminalRef.current.scrollToBottom();
+      }
     }
   }));
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,4 +36,14 @@ export default defineConfig([
       },
     },
   },
+  // Configuration for helper and runner servers (Node.js environment)
+  {
+    files: ['helper/server.js', 'runner/server.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+  },
 ])

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-command-helper",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.1.0-rc3",
+  "version": "1.1.0-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.1.0-rc3",
+      "version": "1.1.0-rc4",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.1.0-rc3",
+  "version": "1.1.0-rc4",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-runner",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",


### PR DESCRIPTION
helper/server.js:
- Disable Node.js HTTP server timeouts for long-running commands (20+ minutes)
- Add 5-second keep-alive SSE pings to prevent proxy/browser timeouts
- Add /discover endpoint: spawns 'docker exec ... php bin/console list --format=json', filters app:strava:* commands
- Improve error handling with connection-closed guards and cleanup logic

runner/server.js:
- Disable all HTTP server timeouts for long-running commands
- Fix AbortController for client disconnect propagation (created before fetch, passed to signal)
- Add /discover proxy endpoint with 35-second timeout

app/api/strava-console/route.js:
- Add maxDuration = 1800 (30 minutes) for long-running Symfony commands

app/api/strava-console/discover/route.js:
- Create new API route proxying to runner's /discover with 40-second timeout

useStravaConsole.js:
- Add keep-alive ping filtering (skip SSE comments starting with ':')
- Implement connection state machine: idle -> connecting -> running -> streaming -> completed/error/disconnected
- Add elapsed time counter with 1-second interval updates
- Add auto-scroll support with toggleable reference
- Add command discovery functions: discoverCommands, clearDiscovered
- Filter keep-alive pings in SSE stream parsing

StravaConsoleTerminal.jsx:
- Add scrollToBottom method to imperative handle for auto-scroll support

StravaConsole.jsx:
- Add connection state badges: Running (green spinner), Streaming (blue spinner), Completed/Error/Disconnected
- Add elapsed timer display showing H:MM:SS or M:SS format
- Add auto-scroll toggle button with blue highlight when enabled
- Add Discover button (disabled when running/discovering or runner offline)
- Integrate DiscoverCommandsDialog with merge and replace actions

DiscoverCommandsDialog.jsx:
- Create dialog component showing discovered commands in scrollable list
- Highlight new commands with green background and green 'New' badges
- Show summary: '{n} new commands found, {m} already configured'
- Add Merge action: adds only new commands, keeps existing
- Add Replace All action: replaces all with confirmation warning

eslint.config.js:
- Add Node.js globals configuration for helper/server.js and runner/server.js
- Fix 'process is not defined' lint errors in helper and runner

Package versions:
- Bump helper/package.json from 0.3.0 to 0.4.0
- Bump runner/package.json from 0.3.0 to 0.4.0
- Bump stats-for-strava-config-tool from v1.1.0-rc3 to v1.1.0-rc4