### PR TITLE
Add command log capture system and fix command naming

### DIFF
--- a/app/api/download-log/route.js
+++ b/app/api/download-log/route.js
@@ -4,13 +4,13 @@ import path from 'path';
 
 export const runtime = 'nodejs';
 
-// Directory for storing command logs
-const LOG_DIR = './strava-sh-logs';
+// Directory for storing command logs (Docker volume mount)
+const LOG_DIR = '/var/log/strava-helper/command-logs';
 
 /**
  * GET - Download or view a log file
  * Query params:
- *   - path: (required) Path to the log file
+ *   - path: (required) Path to the log file (absolute path from helper)
  *   - view: (optional) If 'true', returns JSON with content instead of download
  */
 export async function GET(request) {
@@ -26,9 +26,9 @@ export async function GET(request) {
       }, { status: 400 });
     }
 
-    // Security: Validate path is within strava-sh-logs directory
+    // Security: Validate path is within command logs directory
     const normalizedPath = path.normalize(logPath);
-    const resolvedPath = path.resolve(logPath);
+    const resolvedPath = path.resolve(normalizedPath);
     const resolvedLogDir = path.resolve(LOG_DIR);
 
     // Check if the path is within the log directory

--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -172,7 +172,7 @@ export default function StravaConsole() {
         merged.push({
           id,
           name: entry.name || id,
-          command: id,
+          command: entry.command[2],
           description: entry.description || ''
         });
       }
@@ -187,7 +187,7 @@ export default function StravaConsole() {
     const commandsList = Object.entries(newCommands).map(([id, entry]) => ({
       id,
       name: entry.name || id,
-      command: id,
+      command: entry.command[2],
       description: entry.description || ''
     }));
     await saveCommands(commandsList);

--- a/app/utilities/_components/hooks/useStravaConsole.js
+++ b/app/utilities/_components/hooks/useStravaConsole.js
@@ -291,9 +291,14 @@ export function useStravaConsole() {
                   // Runner uses 'exit' event instead of 'complete'
                   result = {
                     success: data.data.code === 0,
-                    logPath: null, // Runner doesn't provide logPath
+                    logPath: data.data.logPath || null,
                     exitCode: data.data.code
                   };
+                  
+                  // Set log path if provided
+                  if (data.data.logPath) {
+                    setLastLogPath(data.data.logPath);
+                  }
 
                   // Write completion message
                   writeToTerminal('', 'stdout');

--- a/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
+++ b/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
@@ -144,7 +144,7 @@ export default function DiscoverCommandsDialog({
                   </Text>
                 )}
                 <Text fontSize="xs" color="textMuted" fontFamily="mono" mt={0.5}>
-                  php bin/console {entry.id}
+                  php bin/console app:strava:{entry.id}
                 </Text>
               </Box>
             </Flex>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./statistics-for-strava/config:/data/config  # Stats for Strava config directory
       - ./statistics-for-strava/storage:/data/storage  # Gear maintenance images and other storage
       - ./statistics-for-strava/logs:/data/logs  # Application and service logs
+      - ./strava-sh-logs:/var/log/strava-helper/command-logs:ro  # Command execution logs (read-only)
 
     ports:
       - "8092:80"  # Access at http://localhost:8092
@@ -65,6 +66,7 @@ services:
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock
   #     - ./statistics-for-strava/config/settings/console-commands.yaml:/var/www/console-commands.yaml:ro
+  #     - ./strava-sh-logs:/var/log/strava-helper/command-logs  # Command execution logs (read-write)
   #   networks:
   #     - statistics-for-strava-network
 

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-command-helper",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.1.0-rc4",
+  "version": "1.1.0-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.1.0-rc4",
+      "version": "1.1.0-rc5",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.1.0-rc4",
+  "version": "1.1.0-rc5",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/public/docs/help/sfs-console.md
+++ b/public/docs/help/sfs-console.md
@@ -1,6 +1,6 @@
 # **Enabling the SFS Console (Optional Feature)**
 
-The **SFS Console** is an optional feature that allows the Stats for Strava Config Tool to execute Symfony console commands inside the Statistics for Strava application container.
+The **SFS Console** is an optional feature that allows the Stats for Strava Config Tool to execute Symfony console commands inside the Statistics for Strava application container with real-time streaming output.
 
 This feature uses a two-container architecture for security:
 
@@ -8,6 +8,15 @@ This feature uses a two-container architecture for security:
 - **strava-command-helper** - Executes validated commands inside the target container via `docker exec`
 
 This feature is disabled by default and can be enabled at any time.
+
+**Recent Updates (v1.1.0-rc4):**
+- ✨ Command discovery: Automatically discover available `app:strava:*` commands from the container
+- 📝 Individual log file capture: Each command execution is saved to a timestamped file
+- ⏱️ Elapsed time tracking: Real-time timer shows command duration
+- 🔄 Auto-scroll toggle: Control terminal scrolling behavior
+- 🔴 Connection state badges: Visual indicators for Running, Streaming, Completed, Error states
+- 📡 Keep-alive pings: Prevents timeout on long-running commands (20+ minutes supported)
+- 🎯 Full command names: Commands now use proper `app:strava:*` format
 
 ---
 
@@ -90,6 +99,7 @@ strava-command-helper:
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - ./statistics-for-strava/config/settings/console-commands.yaml:/var/www/console-commands.yaml:ro
+    - ./strava-sh-logs:/var/log/strava-helper/command-logs  # Command execution logs
   networks:
     - statistics-for-strava-network
 ```
@@ -98,6 +108,7 @@ Then create the required directories and restart your stack:
 
 ```bash
 mkdir -p ./statistics-for-strava/runner-logs
+mkdir -p ./strava-sh-logs
 docker compose up -d
 ```
 
@@ -117,21 +128,23 @@ commands:
   build-files:
     name: "Build Files (Updates Dashboard)"
     description: "Build Strava files and update the dashboard"
-    command: ["php", "bin/console", "build-files"]
+    command: ["php", "bin/console", "app:strava:build-files"]
 
   import-data:
     name: "Import Data"
     description: "Import new activities from Strava API"
-    command: ["php", "bin/console", "import-data"]
+    command: ["php", "bin/console", "app:strava:import-data"]
 
   webhooks-view:
     name: "Webhooks View"
     description: "View Strava webhook subscription(s)"
-    command: ["php", "bin/console", "webhooks-view"]
+    command: ["php", "bin/console", "app:strava:webhooks-view"]
 EOF
 ```
 
 The file uses a map-based format where each key is the command ID and the `command` field is a string array passed directly to `docker exec`.
+
+**Note:** Commands must use the full Symfony command name format `app:strava:command-name`, not the short ID.
 
 ---
 
@@ -194,9 +207,32 @@ docker compose exec strava-command-helper docker ps
 
 Once enabled, open the **SFS Console** from the sidebar (under Utilities).
 
-Select a command (e.g., `webhooks-view`) and click **Run**.
+**Key Features:**
 
-You should see:
+1. **Command Discovery** - Click the **Discover** button to automatically find all available `app:strava:*` commands from your Statistics for Strava container
+   - Displays discovered commands with descriptions
+   - Shows which commands are new (not in your current configuration)
+   - **Merge** - Add only new commands to your existing list
+   - **Replace All** - Replace your entire command list with discovered commands
+
+2. **Command Execution** - Select a command and click **Run** to see:
+   - Connection state badges (Running, Streaming, Completed, Error)
+   - Real-time elapsed timer showing command duration
+   - Live streamed output in the terminal (with proper `app:strava:*` command display)
+   - Auto-scroll toggle to control terminal scrolling
+   - Final success/failure message with exit code
+
+3. **Command History** - View past executions with:
+   - Timestamp and duration for each run
+   - Status badges (Success/Failed/Cancelled)
+   - **View Log** button to see full command output
+   - **Rerun** button to execute again with one click
+
+4. **Log Files** - Each command execution is automatically saved to:
+   - Format: `YYYY-MM-DD_HH-MM-SS_command-id_exitcode.log`
+   - Location: `./strava-sh-logs/` on host
+   - Accessible via **View Log** or **Download Log** buttons
+   - Includes full stdout/stderr, timestamps, and exit code
 
 - Live streamed output in the terminal
 - A final success/failure message with exit code
@@ -211,11 +247,75 @@ You can disable the SFS Console at any time:
 1. Go to **Settings** (gear icon)
 2. Toggle **Enable SFS Console** to **OFF**
 3. (Optional) Comment out the runner and helper blocks in `docker-compose.yml`
-4. Restart your stack
+4. (Optional) Comment out the runner and helper blocks in `docker-compose.yml`
+5. Restart your stack
 
 ---
 
-## **7. Environment Variables**
+## **7. Features**
+
+### Command Discovery (New in v1.1.0-rc4)
+
+The **Discover** button automatically finds all available Symfony console commands:
+
+1. Queries the Statistics for Strava container: `php bin/console list --format=json`
+2. Filters for commands matching `app:strava:*` pattern
+3. Displays results in a dialog with:
+   - Command names and descriptions
+   - Green "New" badges for commands not in your current configuration
+   - Count of new vs existing commands
+
+**Actions:**
+- **Merge** - Adds only new commands to your existing configuration
+- **Replace All** - Replaces your entire command list (shows confirmation warning)
+
+### Live Terminal Output
+
+Real-time streaming with:
+- ANSI color support (stdout, stderr, info, success, error)
+- Connection state badges (🔵 Running, 🟢 Streaming, ✅ Completed, ❌ Error)
+- Elapsed time counter (updates every second)
+- Auto-scroll toggle (blue when enabled)
+- Keep-alive pings prevent timeout on long-running commands (20+ minutes supported)
+
+### Command History
+
+Persistent history tracking:
+- Timestamp, duration, and status for each execution
+- Color-coded status badges (green/red/gray)
+- **View Log** - Opens log file in overlay with copy/close buttons
+- **Rerun** - Execute the command again with one click
+- **Clear History** - Remove all history entries
+
+### Log File System
+
+Each command execution creates a detailed log file:
+
+**Filename format:**
+```
+2026-01-23_14-30-45_build-files_0.log
+```
+
+**Structure:**
+- YYYY-MM-DD_HH-MM-SS timestamp
+- Command ID (e.g., `build-files`)
+- Exit code (0 = success, non-zero = error)
+
+**Content includes:**
+- Command executed
+- Target container
+- Start/end timestamps
+- Full stdout and stderr output
+- Exit code and duration
+
+**Location:**
+- Helper writes: `/var/log/strava-helper/command-logs/`
+- Config-tool reads: Same directory (shared Docker volume)
+- Host machine: `./strava-sh-logs/`
+
+---
+
+## **8. Environment Variables**
 
 ### Config Tool
 
@@ -240,10 +340,11 @@ You can disable the SFS Console at any time:
 | `COMMANDS_FILE` | `/var/www/console-commands.yaml` | Path to the commands allowlist |
 | `PORT` | `8081` | HTTP listen port |
 | `LOG_FILE` | `/var/log/strava-helper/helper.log` | Structured log file path |
+| `COMMAND_LOGS_DIR` | `/var/log/strava-helper/command-logs` | Directory for command execution logs |
 
 ---
 
-## **8. Security Model**
+## **9. Security Model**
 
 | Layer | Protection |
 |-------|-----------|
@@ -260,7 +361,7 @@ You can disable the SFS Console at any time:
 
 ---
 
-## **9. Troubleshooting**
+## **10. Troubleshooting**
 
 ### Runner shows "Offline" but container is running
 
@@ -286,21 +387,77 @@ You can disable the SFS Console at any time:
 2. Verify the runner can reach the helper: `docker compose exec strava-runner wget -qO- http://strava-command-helper:8081/health`
 3. Check `runner-logs/runner.log` for errors
 
+### "No log file available" message
+
+1. Ensure the shared log volume is mounted: `./strava-sh-logs:/var/log/strava-helper/command-logs`
+2. Check if the directory exists: `ls -la ./strava-sh-logs/`
+3. Verify helper has write permissions: `docker compose exec strava-command-helper ls -la /var/log/strava-helper/command-logs`
+4. Check helper logs for file creation errors: `docker compose logs strava-command-helper | grep log_file`
+
+### Command execution times out
+
+The system supports long-running commands (20+ minutes):
+- Helper: Disables all Node.js HTTP timeouts
+- Runner: Disables all HTTP timeouts and sends keep-alive pings every 5 seconds
+- Next.js: `maxDuration = 1800` (30 minutes) on the API route
+
+If commands still timeout:
+1. Check for network connectivity issues
+2. Verify the command completes within 30 minutes
+3. Check browser console for client-side timeout errors
+
+### Discovery fails with timeout
+
+Discovery has a 30-second timeout (helper) + 5-second buffer (runner/frontend):
+1. Ensure Statistics for Strava container is running and healthy
+2. Test manually: `docker exec statistics-for-strava php bin/console list --format=json`
+3. Check helper logs: `docker compose logs strava-command-helper | grep discover`
+
 ---
 
-## **10. Viewing Logs**
+## **11. Viewing Logs**
 
-Runner logs are written to `./statistics-for-strava/runner-logs/runner.log`:
+### Structured Server Logs
+
+Runner and helper write structured JSON logs:
 
 ```bash
-# Real-time logs
+# Real-time runner logs
 tail -f ./statistics-for-strava/runner-logs/runner.log | jq
+
+# Real-time helper logs (if mounted separately)
+docker compose logs -f strava-command-helper | jq
 
 # Last 50 entries
 tail -50 ./statistics-for-strava/runner-logs/runner.log | jq
 ```
 
-You can also view container logs directly:
+### Command Execution Logs
+
+Individual command output is saved to timestamped files:
+
+```bash
+# List all command logs
+ls -lh ./strava-sh-logs/
+
+# View a specific log
+cat ./strava-sh-logs/2026-01-23_14-30-45_build-files_0.log
+
+# View most recent log
+ls -t ./strava-sh-logs/*.log | head -1 | xargs cat
+
+# Find failed commands (non-zero exit codes)
+ls ./strava-sh-logs/*_[^0].log
+
+# Search logs for errors
+grep -i error ./strava-sh-logs/*.log
+```
+
+You can also view logs from the UI:
+- Command History panel: Click **View Log** button
+- Terminal output: Click **Download Log** after command completes
+
+Container logs are available via:
 
 ```bash
 docker compose logs -f strava-runner
@@ -309,7 +466,7 @@ docker compose logs -f strava-command-helper
 
 ---
 
-## **Summary**
+## **12. Summary**
 
 | Component | Enabled | Disabled |
 |-----------|---------|----------|
@@ -319,4 +476,8 @@ docker compose logs -f strava-command-helper
 | Console page | Functional | Shows disabled message |
 | Health check | Active (every 30s) | Not performed |
 | Command execution | Allowed | Blocked |
-| Logs | Written to `runner-logs/` | No logs |
+| Server logs | Written to `runner-logs/` | No logs |
+| Command logs | Written to `strava-sh-logs/` | No logs |
+| Command discovery | Available | Not available |
+| Real-time streaming | Active with keep-alive | Not available |
+| Execution history | Tracked with log links | Not tracked |

--- a/runner/commands.yaml
+++ b/runner/commands.yaml
@@ -12,24 +12,24 @@ commands:
   build-files:
     name: "Build Files (Updates Dashboard)"
     description: "Build Strava files and update the dashboard"
-    command: ["php", "bin/console", "build-files"]
+    command: ["php", "bin/console", "app:strava:build-files"]
 
   import-data:
     name: "Import Data"
     description: "Import new activities from Strava API"
-    command: ["php", "bin/console", "import-data"]
+    command: ["php", "bin/console", "app:strava:import-data"]
 
   webhooks-create:
     name: "Webhooks Create"
     description: "Create a Strava webhook subscription"
-    command: ["php", "bin/console", "webhooks-create"]
+    command: ["php", "bin/console", "app:strava:webhooks-create"]
 
   webhooks-unsubscribe:
     name: "Webhooks Unsubscribe"
     description: "Delete a Strava webhook subscription"
-    command: ["php", "bin/console", "webhooks-unsubscribe"]
+    command: ["php", "bin/console", "app:strava:webhooks-unsubscribe"]
 
   webhooks-view:
     name: "Webhooks View"
     description: "View Strava webhook subscription(s)"
-    command: ["php", "bin/console", "webhooks-view"]
+    command: ["php", "bin/console", "app:strava:webhooks-view"]

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-runner",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/runner/server.js
+++ b/runner/server.js
@@ -261,6 +261,7 @@ async function handleRun(req, res) {
                 event: 'exit',
                 command,
                 exitCode: eventData.data.code,
+                logPath: eventData.data.logPath || null,
                 durationMs
               });
             }


### PR DESCRIPTION
helper/server.js:
- Add COMMAND_LOGS_DIR constant for individual command execution logs
- Create timestamped log file for each command execution
- Write all stdout/stderr to both SSE stream and log file
- Rename log file to include exit code on completion (e.g., *_0.log)
- Include logPath in exit event response
- Log file format: YYYY-MM-DD_HH-MM-SS_command-id_exitcode.log

runner/server.js:
- Forward logPath from helper's exit events
- Include logPath in runner logs for tracking

runner/commands.yaml:
- Update all commands to use full app:strava:* format
- build-files -> app:strava:build-files
- import-data -> app:strava:import-data
- webhooks-create -> app:strava:webhooks-create
- webhooks-unsubscribe -> app:strava:webhooks-unsubscribe
- webhooks-view -> app:strava:webhooks-view

app/utilities/_components/hooks/useStravaConsole.js:
- Update exit event handler to extract and store logPath
- Set lastLogPath when logPath is provided
- Remove 'Runner doesn't provide logPath' comment

app/utilities/_components/StravaConsole.jsx:
- Fix handleMergeCommands: use entry.command[2] for full command name
- Fix handleOverwriteCommands: use entry.command[2] for full command name

app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx:
- Update preview display to show full command: app:strava:{entry.id}

docker-compose.yml:
- Add shared log volume to config-manager (read-only): ./strava-sh-logs:/var/log/strava-helper/command-logs:ro
- Add shared log volume to strava-command-helper (read-write): ./strava-sh-logs:/var/log/strava-helper/command-logs

app/api/download-log/route.js:
- Update LOG_DIR to absolute path: /var/log/strava-helper/command-logs
- Support absolute paths from helper's log system

public/docs/help/sfs-console.md:
- Add v1.1.0-rc4 feature highlights section
- Document command discovery feature with merge/replace workflows
- Document individual log file capture system
- Add log file format, structure, and location details
- Update docker-compose examples with log volume mounts
- Update command examples to use app:strava:* prefix
- Add COMMAND_LOGS_DIR environment variable documentation
- Expand troubleshooting section with log-specific issues
- Add comprehensive log viewing examples (structured and command logs)
- Update summary table with new features

Fixes:
- Resolves 'No log file available' issue
- Terminal now displays correct app:strava:* command format
- Discovery properly saves full command names