### PR TITLE
feat: Add command parameter support for SFS Console

### DIFF
--- a/app/api/console-commands/route.js
+++ b/app/api/console-commands/route.js
@@ -67,6 +67,9 @@ function getConsoleCommandsPath(defaultPath) {
  *       name: "Build Files"
  *       description: "Build Strava files"
  *       command: ["php", "bin/console", "build-files"]
+ *       acceptsArgs: true  # optional
+ *       argsDescription: "..."  # optional
+ *       argsPlaceholder: "..."  # optional
  */
 function toYAML(commands) {
   let yaml = '# Console Commands for Statistics for Strava\n';
@@ -79,7 +82,20 @@ function toYAML(commands) {
     yaml += `  ${cmd.id}:\n`;
     yaml += `    name: "${cmd.name}"\n`;
     yaml += `    description: "${cmd.description}"\n`;
-    yaml += `    command: ["php", "bin/console", "${cmd.command}"]\n\n`;
+    yaml += `    command: ["php", "bin/console", "${cmd.command}"]\n`;
+    
+    // Add args fields if present
+    if (cmd.acceptsArgs) {
+      yaml += `    acceptsArgs: true\n`;
+      if (cmd.argsDescription) {
+        yaml += `    argsDescription: "${cmd.argsDescription}"\n`;
+      }
+      if (cmd.argsPlaceholder) {
+        yaml += `    argsPlaceholder: "${cmd.argsPlaceholder}"\n`;
+      }
+    }
+    
+    yaml += '\n';
   });
 
   return yaml;
@@ -105,7 +121,10 @@ export async function GET(request) {
           id,
           name: entry.name || id,
           command: id,
-          description: entry.description || ''
+          description: entry.description || '',
+          acceptsArgs: entry.acceptsArgs || false,
+          argsDescription: entry.argsDescription || '',
+          argsPlaceholder: entry.argsPlaceholder || ''
         }));
         return NextResponse.json({
           success: true,

--- a/app/api/strava-console/route.js
+++ b/app/api/strava-console/route.js
@@ -58,12 +58,20 @@ export async function GET() {
  */
 export async function POST(request) {
   try {
-    const { command } = await request.json();
+    const { command, args = [] } = await request.json();
 
     if (!command) {
       return NextResponse.json({
         success: false,
         error: 'Command is required'
+      }, { status: 400 });
+    }
+
+    // Validate args is array
+    if (!Array.isArray(args)) {
+      return NextResponse.json({
+        success: false,
+        error: 'Arguments must be an array'
       }, { status: 400 });
     }
 
@@ -83,7 +91,7 @@ export async function POST(request) {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ command })
+        body: JSON.stringify({ command, args })
       });
     } catch (fetchError) {
       return NextResponse.json({

--- a/app/utilities/_components/hooks/useCommandHistory.js
+++ b/app/utilities/_components/hooks/useCommandHistory.js
@@ -47,6 +47,7 @@ const saveHistory = (history) => {
  *   id: string,
  *   command: string,        // The command that was run
  *   commandName: string,    // Display name of the command
+ *   args: array,            // Command arguments
  *   timestamp: number,      // When the command was started
  *   status: 'running' | 'success' | 'failed',
  *   logPath: string | null, // Path to log file if available
@@ -65,14 +66,16 @@ export function useCommandHistory() {
    * Add a new command to history
    * @param {string} command - The command being run
    * @param {string} commandName - Display name for the command
+   * @param {Array} args - Command arguments array
    * @returns {string} The ID of the new history item
    */
-  const addToHistory = useCallback((command, commandName) => {
+  const addToHistory = useCallback((command, commandName, args = []) => {
     const id = generateId();
     const newItem = {
       id,
       command,
       commandName: commandName || command,
+      args,
       timestamp: Date.now(),
       status: 'running',
       logPath: null,

--- a/app/utilities/_components/hooks/useStravaConsole.js
+++ b/app/utilities/_components/hooks/useStravaConsole.js
@@ -185,10 +185,11 @@ export function useStravaConsole() {
 
   /**
    * Run the selected command via the Strava Runner sidecar
+   * @param {Array} args - Command arguments array
    * @param {Function} onComplete - Callback when command completes
    * @returns {Promise<{success: boolean, logPath: string|null, exitCode: number|null}>}
    */
-  const runCommand = useCallback(async (onComplete) => {
+  const runCommand = useCallback(async (args = [], onComplete) => {
     const selectedCommand = getSelectedCommand();
     if (!selectedCommand) {
       setError('No command selected');
@@ -215,7 +216,8 @@ export function useStravaConsole() {
       if (terminalRef.current) {
         terminalRef.current.clear();
       }
-      writeToTerminal(`$ php bin/console ${selectedCommand.command}`, 'info');
+      const argsDisplay = args.length > 0 ? ` ${args.join(' ')}` : '';
+      writeToTerminal(`$ php bin/console ${selectedCommand.command}${argsDisplay}`, 'info');
       writeToTerminal('', 'stdout');
 
       // Use the strava-console API (Strava Runner sidecar)
@@ -225,7 +227,8 @@ export function useStravaConsole() {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          command: selectedCommand.command
+          command: selectedCommand.command,
+          args
         }),
         signal: abortControllerRef.current.signal
       });

--- a/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
+++ b/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
@@ -157,9 +157,13 @@ function HistoryItem({ item, index, totalItems, onRerun }) {
             </HStack>
             <Text fontSize="xs" color="textMuted" fontFamily="mono">
               app:strava:{item.command}
+              {item.args && item.args.length > 0 && (
+                <Text as="span" color="blue.500" ml={2}>
+                  {item.args.join(' ')}
+                </Text>
+              )}
             </Text>
-            <Text fontSize="xs" color="textMuted">
-              {formatRelativeTime(item.timestamp)}
+            <Text fontSize="xs" color="textMuted">{formatRelativeTime(item.timestamp)}
               {item.exitCode !== null && item.exitCode !== 0 && (
                 <Text as="span" ml={2} color="red.500">
                   Exit code: {item.exitCode}
@@ -186,7 +190,7 @@ function HistoryItem({ item, index, totalItems, onRerun }) {
             <Button
               size="xs"
               variant="ghost"
-              onClick={() => onRerun(item.command)}
+              onClick={() => onRerun(item.command, item.args)}
               title="Run this command again"
               color="text"
               disabled={item.status === 'running'}

--- a/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
+++ b/app/utilities/_components/strava-console/DiscoverCommandsDialog.jsx
@@ -40,6 +40,7 @@ export default function DiscoverCommandsDialog({
       id,
       name: entry.name || id,
       description: entry.description || '',
+      acceptsArgs: entry.acceptsArgs || false,
       isNew: !existingIds.has(id)
     }));
 
@@ -135,6 +136,11 @@ export default function DiscoverCommandsDialog({
                         <Icon as={MdNewReleases} boxSize={3} />
                         <Text>New</Text>
                       </HStack>
+                    </Badge>
+                  )}
+                  {entry.acceptsArgs && (
+                    <Badge colorPalette="blue" variant="subtle" size="xs">
+                      requires arguments
                     </Badge>
                   )}
                 </HStack>

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-command-helper",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.1.0-rc5",
+  "version": "1.1.0-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.1.0-rc5",
+      "version": "1.1.0-rc6",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.1.0-rc5",
+  "version": "1.1.0-rc6",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/commands.yaml
+++ b/runner/commands.yaml
@@ -7,6 +7,9 @@
 #   - name: Human-readable display name
 #   - description: Brief description of what the command does
 #   - command: Array of strings passed directly to `docker exec` (no shell)
+#   - acceptsArgs: (optional) Boolean indicating if command accepts arguments
+#   - argsDescription: (optional) Description of what arguments the command expects
+#   - argsPlaceholder: (optional) Placeholder text for arguments input field
 
 commands:
   build-files:
@@ -28,6 +31,9 @@ commands:
     name: "Webhooks Unsubscribe"
     description: "Delete a Strava webhook subscription"
     command: ["php", "bin/console", "app:strava:webhooks-unsubscribe"]
+    acceptsArgs: true
+    argsDescription: "Subscription ID to unsubscribe"
+    argsPlaceholder: "Enter subscription ID"
 
   webhooks-view:
     name: "Webhooks View"

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strava-runner",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",


### PR DESCRIPTION
- Add args validation in runner with security checks (no shell metacharacters, flags, or empty strings)
- Implement args support in helper with secure docker exec array construction
- Update discovery endpoint to include args metadata for webhooks-unsubscribe
- Add acceptsArgs, argsDescription, argsPlaceholder fields to YAML schema
- Implement conditional args input field in UI with validation
- Update command history to preserve and restore args on rerun
- Add args display in terminal output and log filenames
- Update API routes to forward args parameter
- Enhance documentation with args usage examples and security details
- Add 'requires arguments' badge to discovery dialog
- Enforce app:strava:* namespace restriction for all commands

This enables commands like webhooks-unsubscribe to accept required parameters (e.g., subscription IDs) while maintaining security through comprehensive validation.