### PR TITLE
fix: Remove unused variable in catch block

### DIFF
--- a/app/utilities/_components/strava-console/StravaConsoleTerminal.jsx
+++ b/app/utilities/_components/strava-console/StravaConsoleTerminal.jsx
@@ -122,7 +122,7 @@ const StravaConsoleTerminal = forwardRef(function StravaConsoleTerminal({ onRead
           if (fitAddon && terminalContainerRef.current) {
             try {
               fitAddon.fit();
-            } catch (e) {
+            } catch {
               // Ignore fit errors during resize
             }
           }


### PR DESCRIPTION
Remove unused 'e' variable from catch block in StravaConsoleTerminal resize observer to fix lint error.