### PR TITLE
fix: Remove duplicate closing tags in StravaConsole

### DIFF
--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -530,8 +530,6 @@ export default function StravaConsole() {
             </HStack>
           </VStack>
         </Box>
-          </VStack>
-        </Box>
 
         {/* Terminal */}
         <Box


### PR DESCRIPTION
Remove duplicate VStack and Box closing tags that were causing build failure. The Command Selection Card Box and VStack were being closed twice, causing parsing errors at line 536.