### PR TITLE
fix: Extract full command name from YAML command array

### DIFF
--- a/app/api/console-commands/route.js
+++ b/app/api/console-commands/route.js
@@ -117,15 +117,22 @@ export async function GET(request) {
 
       if (parsed?.commands && typeof parsed.commands === 'object' && !Array.isArray(parsed.commands)) {
         // New map-based format
-        const commands = Object.entries(parsed.commands).map(([id, entry]) => ({
-          id,
-          name: entry.name || id,
-          command: id,
-          description: entry.description || '',
-          acceptsArgs: entry.acceptsArgs || false,
-          argsDescription: entry.argsDescription || '',
-          argsPlaceholder: entry.argsPlaceholder || ''
-        }));
+        const commands = Object.entries(parsed.commands).map(([id, entry]) => {
+          // Extract the actual command name from the command array (last element)
+          const commandName = Array.isArray(entry.command) && entry.command.length > 0
+            ? entry.command[entry.command.length - 1]
+            : id;
+          
+          return {
+            id,
+            name: entry.name || id,
+            command: commandName,
+            description: entry.description || '',
+            acceptsArgs: entry.acceptsArgs || false,
+            argsDescription: entry.argsDescription || '',
+            argsPlaceholder: entry.argsPlaceholder || ''
+          };
+        });
         return NextResponse.json({
           success: true,
           commands,


### PR DESCRIPTION
Fix console-commands API to extract the actual command name (e.g., app:strava:webhooks-view) from the command array instead of using the command ID. This resolves the issue where commands were being sent without the app:strava: prefix, causing runner validation to reject them.