### PR TITLE
Feature/strava runner - Use full command name as key in runner's allowed commands map

### DIFF
--- a/runner/server.js
+++ b/runner/server.js
@@ -78,8 +78,12 @@ function loadCommands() {
         if (Array.isArray(entry.command) && entry.command.length > 0) {
           // Validate all command array elements are strings
           if (entry.command.every(arg => typeof arg === 'string')) {
-            allowedCommands.set(id, {
+            // Extract the full command name (last element of command array)
+            // e.g., ["php", "bin/console", "app:strava:webhooks-view"] -> "app:strava:webhooks-view"
+            const commandName = entry.command[entry.command.length - 1];
+            allowedCommands.set(commandName, {
               ...entry,
+              id, // Keep the original ID for reference
               acceptsArgs: entry.acceptsArgs || false,
               argsDescription: entry.argsDescription,
               argsPlaceholder: entry.argsPlaceholder


### PR DESCRIPTION
Update runner to use the full command name (e.g., app:strava:webhooks-view) extracted from the YAML command array as the map key, instead of using the command ID. This matches what the frontend now sends after extracting the full command name from the YAML."