### PR TITLE
fix: Use full command name as key in helper's allowed commands map

### DIFF
--- a/helper/server.js
+++ b/helper/server.js
@@ -71,7 +71,13 @@ function loadCommands() {
         if (Array.isArray(entry.command) && entry.command.length > 0) {
           // Validate all command array elements are strings
           if (entry.command.every(arg => typeof arg === 'string')) {
-            allowedCommands.set(id, entry);
+            // Extract the full command name (last element of command array)
+            // e.g., ["php", "bin/console", "app:strava:webhooks-view"] -> "app:strava:webhooks-view"
+            const fullCommandName = entry.command[entry.command.length - 1];
+            allowedCommands.set(fullCommandName, {
+              ...entry,
+              id // Keep the original short ID for reference
+            });
           }
         }
       }


### PR DESCRIPTION
Update helper to match runner's fix - use the full command name (e.g., app:strava:webhooks-view) extracted from the YAML command array as the map key, instead of using the command ID. This ensures the helper can look up commands correctly when the runner forwards requests.