### PR TITLE
feat: Add navigation protection during command execution

### DIFF
--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -296,7 +296,31 @@ export default function StravaConsole() {
 
   return (
     <Box p={6} minH="100vh" bg="bg">
-      <VStack align="stretch" gap={6} maxW="1400px" mx="auto">
+      {/* Warning Banner - Command Running */}
+      {isRunning && (
+        <Box
+          position="fixed"
+          top={0}
+          left={0}
+          right={0}
+          bg="orange.500"
+          color="white"
+          py={2}
+          px={4}
+          textAlign="center"
+          zIndex={9999}
+          fontWeight="bold"
+          boxShadow="lg"
+        >
+          <HStack justify="center" gap={2}>
+            <Icon as={MdWarning} boxSize={5} />
+            <Text>Command Running - Do Not Close This Page or Navigate Away</Text>
+            <Icon as={MdWarning} boxSize={5} />
+          </HStack>
+        </Box>
+      )}
+
+      <VStack align="stretch" gap={6} maxW="1400px" mx="auto" mt={isRunning ? 12 : 0}>
         {/* Header */}
         <Flex justify="space-between" align="center" wrap="wrap" gap={4}>
           <HStack gap={3}>

--- a/app/utilities/_components/hooks/useStravaConsole.js
+++ b/app/utilities/_components/hooks/useStravaConsole.js
@@ -104,6 +104,23 @@ export function useStravaConsole() {
     }
   }, [isFeatureEnabled, checkRunnerHealth]);
 
+  // Warn user before leaving page during command execution
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (isRunning) {
+        e.preventDefault();
+        e.returnValue = ''; // Chrome requires returnValue to be set
+        return ''; // Some browsers return this message
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isRunning]);
+
   /**
    * Load available commands from the API
    */


### PR DESCRIPTION
- Add beforeunload event listener to warn users before leaving page when command is running
- Add fixed orange warning banner at top of page during command execution
- Banner displays 'Command Running - Do Not Close This Page or Navigate Away' with warning icons
- Prevents accidental navigation that would interrupt running commands
- Banner disappears automatically when command completes