### PR TITLE
fix: resolve settings persistence, sidebar expansion, and documentati…

### DIFF
--- a/app/_components/layout/Sidebar.jsx
+++ b/app/_components/layout/Sidebar.jsx
@@ -109,7 +109,10 @@ const MenuItemWithSubmenu = ({
         </Flex>
         {!isCollapsed && (
           <IconButton
-            onClick={onToggle}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle();
+            }}
             aria-label="Toggle submenu"
             size="sm"
             variant="ghost"

--- a/app/_config/pages.js
+++ b/app/_config/pages.js
@@ -181,6 +181,13 @@ export const pages = {
     parent: 'Documentation',
     group: 'help',
     helpFile: 'configuration-examples.md'
+  },
+  'SFS Console Help': {
+    id: 'SFS Console Help',
+    label: 'SFS Console',
+    parent: 'Documentation',
+    group: 'help',
+    helpFile: 'sfs-console.md'
   }
 };
 

--- a/app/docs/[slug]/page.jsx
+++ b/app/docs/[slug]/page.jsx
@@ -32,6 +32,10 @@ const docConfig = {
   'authentication': {
     file: 'authentication.md',
     pageName: 'Authentication Help'
+  },
+  'sfs-console': {
+    file: 'sfs-console.md',
+    pageName: 'SFS Console Help'
   }
 }
 

--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -272,7 +272,7 @@ export default function StravaConsole() {
               <HStack gap={3} mt={4}>
                 <Button
                   as="a"
-                  href="/help/sfs-console"
+                  href="/docs/sfs-console"
                   colorPalette="blue"
                   variant="outline"
                   size="sm"

--- a/app/utilities/_components/common/FileManagerDialog.jsx
+++ b/app/utilities/_components/common/FileManagerDialog.jsx
@@ -158,13 +158,19 @@ export default function FileManagerDialog({
 
             {/* Bulk Actions */}
             <Flex gap={2} direction={{ base: "column", sm: "row" }} align="stretch">
-              <Checkbox
-                checked={allSelected}
-                indeterminate={someSelected}
-                onCheckedChange={handleSelectAll}
-              >
-                <Text fontSize={{ base: "xs", sm: "sm" }}>Select All</Text>
-              </Checkbox>
+              <HStack>
+                <Checkbox.Root
+                  checked={allSelected}
+                  indeterminate={someSelected}
+                  onCheckedChange={handleSelectAll}
+                >
+                  <Checkbox.HiddenInput />
+                  <Checkbox.Control />
+                  <Checkbox.Label>
+                    <Text fontSize={{ base: "xs", sm: "sm" }}>Select All</Text>
+                  </Checkbox.Label>
+                </Checkbox.Root>
+              </HStack>
               {canDelete && (
                 <Button
                   size="sm"
@@ -217,7 +223,7 @@ export default function FileManagerDialog({
                         return (
                           <Table.Row key={fileId}>
                             <Table.Cell>
-                              <Checkbox
+                              <Checkbox.Root
                                 checked={selectedFiles.has(fileId)}
                                 onCheckedChange={(e) => {
                                   const newSet = new Set(selectedFiles);
@@ -228,7 +234,10 @@ export default function FileManagerDialog({
                                   }
                                   setSelectedFiles(newSet);
                                 }}
-                              />
+                              >
+                                <Checkbox.HiddenInput />
+                                <Checkbox.Control />
+                              </Checkbox.Root>
                             </Table.Cell>
                             {renderRow(file, columns, false)}
                             <Table.Cell>
@@ -269,7 +278,7 @@ export default function FileManagerDialog({
                         bg="bg"
                       >
                         <HStack justify="space-between" mb={2}>
-                          <Checkbox
+                          <Checkbox.Root
                             checked={selectedFiles.has(fileId)}
                             onCheckedChange={(e) => {
                               const newSet = new Set(selectedFiles);
@@ -280,7 +289,10 @@ export default function FileManagerDialog({
                               }
                               setSelectedFiles(newSet);
                             }}
-                          />
+                          >
+                            <Checkbox.HiddenInput />
+                            <Checkbox.Control />
+                          </Checkbox.Root>
                           {canDownload && (
                             <Button
                               size="xs"

--- a/src/components/settings/UISettingsModal.jsx
+++ b/src/components/settings/UISettingsModal.jsx
@@ -24,8 +24,8 @@ const UISettingsModal = ({ isOpen, onClose, embedded = false }) => {
   useEffect(() => {
     if (isOpen) {
       // Use queueMicrotask to defer state updates and avoid cascading renders
-      queueMicrotask(() => {
-        const loaded = loadSettings();
+      queueMicrotask(async () => {
+        const loaded = await loadSettings();
         setSettings(loaded);
         setIsDirty(false);
       });


### PR DESCRIPTION
…on routing issues

- Fix settings not persisting: Make loadSettings() properly await async function
- Fix sidebar menu expansion bug: Add stopPropagation to prevent both groups expanding
- Fix Checkbox components: Use Chakra UI v3 composition pattern (Checkbox.Root/Control/Label)
- Add SFS Console documentation routing: Register /docs/sfs-console route
- Add SFS Console to Documentation sidebar menu
- Fix documentation button link in StravaConsole from /help to /docs

Resolves:
- Enable SFS Console setting now persists after browser refresh
- Clicking Utilities no longer expands Configuration menu simultaneously
- FileManagerDialog checkboxes render correctly without React errors
- SFS Console documentation accessible from both button and sidebar