### PR TITLE
fix(file-manager): improve modal behavior and text visibility in dark…

### DIFF
--- a/app/utilities/_components/common/FileManagerDialog.jsx
+++ b/app/utilities/_components/common/FileManagerDialog.jsx
@@ -18,10 +18,13 @@ import {
   DialogFooter,
   DialogCloseTrigger,
   DialogTitle,
+  DialogBackdrop,
+  DialogPositioner,
+  Portal,
   Alert,
   Checkbox
 } from '@chakra-ui/react';
-import { MdDelete, MdDownload } from 'react-icons/md';
+import { MdDelete, MdDownload, MdClose } from 'react-icons/md';
 
 function formatBytes(bytes) {
   if (bytes === 0) return '0 Bytes';
@@ -125,11 +128,26 @@ export default function FileManagerDialog({
 
   return (
     <DialogRoot open={isOpen} onOpenChange={(e) => !e.open && onClose()} size="xl">
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        <DialogCloseTrigger />
+      <Portal>
+        <DialogBackdrop />
+        <DialogPositioner>
+          <DialogContent 
+            maxW="800px" 
+            bg="cardBg"
+            borderRadius="lg"
+            boxShadow="xl"
+          >
+            <DialogHeader>
+              <DialogTitle>{title}</DialogTitle>
+            </DialogHeader>
+            <DialogCloseTrigger 
+              color="fg.muted"
+              _hover={{ 
+                color: "fg", 
+                bg: "gray.100", 
+                _dark: { bg: "gray.700" } 
+              }}
+            />
         
         <DialogBody>
           <VStack align="stretch" gap={4}>
@@ -139,10 +157,10 @@ export default function FileManagerDialog({
                 formatSummary(metadata, files)
               ) : (
                 <Flex justify="space-between" direction={{ base: "column", sm: "row" }} gap={{ base: 1, sm: 0 }}>
-                  <Text fontSize={{ base: "xs", sm: "sm" }} color="fg.muted">
+                  <Text fontSize={{ base: "xs", sm: "sm" }} color="fg">
                     Total: {metadata.totalCount} files
                   </Text>
-                  <Text fontSize={{ base: "xs", sm: "sm" }} color="fg.muted">
+                  <Text fontSize={{ base: "xs", sm: "sm" }} color="fg">
                     Storage: {formatBytes(metadata.totalSize || 0)}
                   </Text>
                 </Flex>
@@ -322,6 +340,8 @@ export default function FileManagerDialog({
           </Button>
         </DialogFooter>
       </DialogContent>
-    </DialogRoot>
+    </DialogPositioner>
+  </Portal>
+</DialogRoot>
   );
 }

--- a/app/utilities/_components/strava-console/LogManagementDialog.jsx
+++ b/app/utilities/_components/strava-console/LogManagementDialog.jsx
@@ -55,12 +55,22 @@ export default function LogManagementDialog({ isOpen, onClose }) {
     return (
       <>
         <Table.Cell>
-          <Text fontSize="xs" fontFamily="mono" color="fg">
+          <Text 
+            fontSize="xs" 
+            fontFamily="mono" 
+            color="gray.900" 
+            _dark={{ color: "gray.100" }}
+          >
             {log.timestamp}
           </Text>
         </Table.Cell>
         <Table.Cell>
-          <Text fontSize="xs" fontFamily="mono" color="fg">
+          <Text 
+            fontSize="xs" 
+            fontFamily="mono" 
+            color="gray.900" 
+            _dark={{ color: "gray.100" }}
+          >
             {log.command}
           </Text>
         </Table.Cell>


### PR DESCRIPTION
… mode

- Add Portal, DialogBackdrop, and DialogPositioner for proper modal behavior
- Fix modal closing on scroll by wrapping in Portal structure
- Style DialogCloseTrigger with hover states for visibility in light/dark modes
- Change summary text color from fg.muted to fg for better readability
- Add explicit dark mode colors (gray.900/_dark:gray.100) to log table cells
- Ensure Date/Time, Command, and Size columns are clearly visible in dark mode

Fixes:
- Modal no longer closes when scrolling browser
- Close button (X) visible in both light and dark modes
- Summary text (Total/Storage) has proper contrast
- Log list entries readable in dark mode