### PR TITLE
feat(file-manager): add delete confirmation, view log, and fix hydrat…

### DIFF
--- a/app/utilities/_components/strava-console/LogManagementDialog.jsx
+++ b/app/utilities/_components/strava-console/LogManagementDialog.jsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Badge, Icon, Text, Table, HStack, Box } from '@chakra-ui/react';
-import { MdCheckCircle, MdError } from 'react-icons/md';
+import { useState } from 'react';
+import { Badge, Icon, Text, Table, HStack, Box, Dialog, Portal, Button, VStack } from '@chakra-ui/react';
+import { MdCheckCircle, MdError, MdClose } from 'react-icons/md';
 import FileManagerDialog from '../common/FileManagerDialog';
 
 function formatBytes(bytes) {
@@ -13,6 +14,20 @@ function formatBytes(bytes) {
 }
 
 export default function LogManagementDialog({ isOpen, onClose }) {
+  const [logCount, setLogCount] = useState(0);
+  const [viewingLog, setViewingLog] = useState(null);
+
+  const handleViewLog = async (log) => {
+    try {
+      const url = `/api/download-log?path=${encodeURIComponent(log.path)}`;
+      const response = await fetch(url);
+      const content = await response.text();
+      setViewingLog({ ...log, content });
+    } catch (error) {
+      console.error('Failed to load log:', error);
+    }
+  };
+
   const columns = [
     { header: 'Date/Time', width: 'auto' },
     { header: 'Command', width: 'auto' },
@@ -85,18 +100,86 @@ export default function LogManagementDialog({ isOpen, onClose }) {
   };
 
   return (
-    <FileManagerDialog
-      isOpen={isOpen}
-      onClose={onClose}
-      title="Manage Command Logs"
-      apiEndpoint="/api/console-logs"
-      columns={columns}
-      renderRow={renderRow}
-      canDownload={true}
-      canDelete={true}
-      downloadUrlGenerator={(log) => 
-        `/api/download-log?path=${encodeURIComponent(log.path)}`
-      }
-    />
+    <>
+      <FileManagerDialog
+        isOpen={isOpen}
+        onClose={onClose}
+        title={`Manage Command Logs${logCount > 0 ? ` (${logCount})` : ''}`}
+        apiEndpoint="/api/console-logs"
+        columns={columns}
+        renderRow={renderRow}
+        canDownload={true}
+        canDelete={true}
+        canView={true}
+        onView={handleViewLog}
+        onFilesLoaded={(files) => setLogCount(files.length)}
+        downloadUrlGenerator={(log) => 
+          `/api/download-log?path=${encodeURIComponent(log.path)}`
+        }
+      />
+
+      {/* Log Viewer Dialog */}
+      {viewingLog && (
+        <Dialog.Root open={!!viewingLog} onOpenChange={(e) => !e.open && setViewingLog(null)} size="xl">
+          <Portal>
+            <Dialog.Backdrop />
+            <Dialog.Positioner>
+              <Dialog.Content maxW="900px" maxH="80vh" bg="cardBg">
+                <Dialog.Header
+                  bg="#E2E8F0"
+                  _dark={{ bg: "#334155" }}
+                >
+                  <Dialog.Title color="#1a202c" _dark={{ color: "#f7fafc" }}>
+                    Log: {viewingLog.command} - {viewingLog.timestamp}
+                  </Dialog.Title>
+                </Dialog.Header>
+                <Dialog.CloseTrigger
+                  asChild
+                  position="absolute"
+                  top={3}
+                  right={3}
+                >
+                  <Button variant="ghost" size="sm">
+                    <Icon as={MdClose} />
+                  </Button>
+                </Dialog.CloseTrigger>
+                <Dialog.Body>
+                  <VStack align="stretch" gap={2}>
+                    <HStack justify="space-between">
+                      <Text fontSize="sm" fontWeight="medium">Status:</Text>
+                      {viewingLog.exitCode === 0 ? (
+                        <Badge colorPalette="green">
+                          <Icon as={MdCheckCircle} /> Success
+                        </Badge>
+                      ) : (
+                        <Badge colorPalette="red">
+                          <Icon as={MdError} /> Failed (Exit Code: {viewingLog.exitCode})
+                        </Badge>
+                      )}
+                    </HStack>
+                    <Box
+                      p={4}
+                      bg="gray.100"
+                      _dark={{ bg: "gray.900" }}
+                      borderRadius="md"
+                      fontFamily="mono"
+                      fontSize="xs"
+                      whiteSpace="pre-wrap"
+                      overflowY="auto"
+                      maxH="60vh"
+                    >
+                      {viewingLog.content}
+                    </Box>
+                  </VStack>
+                </Dialog.Body>
+                <Dialog.Footer>
+                  <Button onClick={() => setViewingLog(null)}>Close</Button>
+                </Dialog.Footer>
+              </Dialog.Content>
+            </Dialog.Positioner>
+          </Portal>
+        </Dialog.Root>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
…ion errors

- Fix React hydration error #418: Remove Text wrappers from Checkbox.Label and Button
- Add delete confirmation dialog before file deletion
- Add View button (eye icon) to view log file contents in modal
- Add dynamic log count in title: 'Manage Command Logs (X)'
- Implement log viewer dialog with full content display
- Add enhanced error handling with console logging for debugging
- Add success message display after successful deletion
- Add onView and onFilesLoaded callback props to FileManagerDialog
- Wrap return in Fragment to support multiple root elements

Fixes:
- Hydration mismatch causing minified React error #418
- Delete button now shows confirmation before deletion
- Users can view log contents without downloading
- Better visibility into delete operation success/failure
- Debug logging helps identify permission or API issues