### PR TITLE
fix: parse log filenames correctly and improve dark mode table headers

### DIFF
--- a/app/utilities/_components/common/FileManagerDialog.jsx
+++ b/app/utilities/_components/common/FileManagerDialog.jsx
@@ -281,11 +281,24 @@ export default function FileManagerDialog({
                       <Table.Row>
                         <Table.ColumnHeader width="40px"></Table.ColumnHeader>
                         {columns.map((col, idx) => (
-                          <Table.ColumnHeader key={idx} width={col.width}>
+                          <Table.ColumnHeader 
+                            key={idx} 
+                            width={col.width}
+                            color="gray.700"
+                            _dark={{ color: "gray.200" }}
+                            fontWeight="semibold"
+                          >
                             {col.header}
                           </Table.ColumnHeader>
                         ))}
-                        <Table.ColumnHeader width="80px">Actions</Table.ColumnHeader>
+                        <Table.ColumnHeader 
+                          width="80px"
+                          color="gray.700"
+                          _dark={{ color: "gray.200" }}
+                          fontWeight="semibold"
+                        >
+                          Actions
+                        </Table.ColumnHeader>
                       </Table.Row>
                     </Table.Header>
                     <Table.Body>


### PR DESCRIPTION
- Update filename parsing to handle YYYY-MM-DDTHH-MM-SS format with namespace
- Extract command from 'app:strava:COMMAND' pattern (takes last segment)
- Convert timestamp format properly (T to space, dashes to colons for time)
- Add explicit colors to table headers for dark mode visibility (gray.200)
- Add fontWeight semibold to table headers for better readability