### PR TITLE
refactor: separate authentication config and fix environment variable…

### DIFF
--- a/.env.config-tool.example
+++ b/.env.config-tool.example
@@ -1,11 +1,28 @@
-# Authentication Configuration
-# This file is used specifically for the config-tool container to avoid
-# Docker Compose variable expansion warnings with bcrypt password hashes
+# Config Tool Authentication Configuration
+# This file contains authentication and session settings for the Stats for Strava Config Tool.
+#
+# IMPORTANT: Copy this file to .env.config-tool before starting the container
+#   cp .env.config-tool.example .env.config-tool
+#
+# NOTE: This file is separate from .env to avoid Docker Compose variable expansion issues.
+# Bcrypt password hashes contain $ characters that conflict with Docker Compose's ${VAR} syntax.
+
+# Authentication
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD_HASH=
 PASSWORD_RESET_TOKEN=
 SESSION_SECRET=change-this-to-a-long-random-secret-string
 SESSION_MAX_AGE=604800
 
-# Debug Logging (set to 'true' to enable verbose console logs)
+# How to Generate a Secure SESSION_SECRET:
+# PowerShell (Windows):
+#   -join ((1..64) | ForEach-Object { '{0:X}' -f (Get-Random -Maximum 16) })
+#
+# Linux/Mac:
+#   openssl rand -hex 32
+#
+# Node.js (any platform):
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+# Debug Logging (set to 'true' to enable verbose console logs, 'false' for production)
 NEXT_PUBLIC_ENABLE_DEBUG_LOGS=false

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
-# Settings Configuration
+# Config Tool Settings
 DEFAULT_STATS_CONFIG_PATH=/data/config/
 DEFAULT_GEAR_MAINTENANCE_PATH=/data/storage/gear-maintenance
 
 # Stats Command Runner (Optional - for SFS Console feature)
 # Default points to stats-cmd-runner container when using docker-compose.yml
 STATS_CMD_RUNNER_URL=http://stats-cmd-runner:8080
+
+# Stats Command Helper Port (Optional - internal port for helper container)
+# Only change if port 8081 conflicts with another service
+STATS_CMD_HELPER_PORT=8081
 
 # UID/GID Mapping (CRITICAL - must be consistent across ALL containers)
 # All containers use these values to ensure file permissions match between:
@@ -15,21 +19,8 @@ STATS_CMD_RUNNER_URL=http://stats-cmd-runner:8080
 # 
 # Linux/Mac: Use your user's UID/GID (run: id -u and id -g)
 # Windows: Use 1000:1000 (Docker Desktop handles mapping automatically)
-#
-# Docker User Mapping (set to match your host user)
-# On Linux, use: id -u and id -g to get your UID/GID
-# On Windows with Docker Desktop, typically 1000:1000 works
 USERMAP_UID=1000
 USERMAP_GID=1000
 
-# Authentication Configuration
-# NOTE: If using this file with other services in docker-compose.yml, rename it to
-# .env.config-tool to avoid Docker Compose variable expansion warnings with bcrypt hashes
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD_HASH=
-PASSWORD_RESET_TOKEN=
-SESSION_SECRET=change-this-to-a-long-random-secret-string
-SESSION_MAX_AGE=604800
-
-# Debug Logging (set to 'true' to enable verbose console logs, 'false' for production)
-NEXT_PUBLIC_ENABLE_DEBUG_LOGS=false
+# Timezone (optional)
+TZ=UTC

--- a/README.md
+++ b/README.md
@@ -152,35 +152,28 @@ services:
 
 This tool uses **two separate .env files** to avoid Docker Compose variable expansion issues with bcrypt password hashes:
 
-1. **`.env`** - Docker Compose variables (volume paths, UID/GID)
-2. **`.env.config-tool`** - Authentication settings (mounted into container)
+1. **`.env`** - Docker Compose variables (volume paths, UID/GID, timezone) - Copy from `.env.example`
+2. **`.env.config-tool`** - Authentication settings (mounted into container) - Copy from `.env.config-tool.example`
 
-**Create `.env` file** in the same directory as your `docker-compose.yml`:
+**Create `.env` file** (copy from `.env.example`) in the same directory as your `docker-compose.yml`:
 
 ```bash
-# Path where Stats for Strava stores config.yaml
-DEFAULT_STATS_CONFIG_PATH=/data/config
+# Copy the example file
+cp .env.example .env
 
-# Path where gear maintenance files are stored
-DEFAULT_GEAR_MAINTENANCE_PATH=/data/storage/gear-maintenance
-
-# User/Group ID for file permissions (Linux/Mac)
-USERMAP_UID=1000
-USERMAP_GID=1000
+# Edit and customize:
+nano .env
 ```
 
 **Create `.env.config-tool` file** (copy from `.env.config-tool.example`):
 
 ```bash
-# Authentication Configuration
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD_HASH=
-PASSWORD_RESET_TOKEN=
-SESSION_SECRET=change-this-to-a-long-random-secret-string
-SESSION_MAX_AGE=604800
+# Copy the example file
+cp .env.config-tool.example .env.config-tool
 
-# Debug Logging
-NEXT_PUBLIC_ENABLE_DEBUG_LOGS=false
+# Generate a secure SESSION_SECRET (see below)
+# Edit and customize:
+nano .env.config-tool
 ```
 
 ⚠️ **IMPORTANT**: The `.env.config-tool` file must be **writable** by the container (UID/GID 1000) so the app can update password hashes during registration and password resets.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   #     - TZ=${TZ}
   #     - USERMAP_UID=${USERMAP_UID}
   #     - USERMAP_GID=${USERMAP_GID}
-  #     - HELPER_URL=http://stats-cmd-helper:${HELPER_PORT:-8081}
+  #     - HELPER_URL=http://stats-cmd-helper:${STATS_CMD_HELPER_PORT:-8081}
   #   
   #   # ⚠️ IMPORTANT: console-commands.yaml Setup
   #   # This MUST be a FILE, not a directory, or containers will fail to start.
@@ -78,7 +78,7 @@ services:
   #   command: ["node", "server.js"]
   #   environment:
   #     - TZ=${TZ}
-  #     - PORT=${HELPER_PORT:-8081}
+  #     - PORT=${STATS_CMD_HELPER_PORT:-8081}
   #     - TARGET_CONTAINER=statistics-for-strava
   #   volumes:
   #     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
… naming

- Separate authentication variables into .env.config-tool.example
- Remove auth variables from .env.example (cleaner separation)
- Add SESSION_SECRET generation instructions to .env.config-tool.example
- Fix HELPER_PORT -> STATS_CMD_HELPER_PORT throughout docker-compose.yml
- Add STATS_CMD_HELPER_PORT to .env.example with documentation
- Update README two-file strategy to reference both .example files
- Add timezone (TZ) variable to .env.example

This clarifies the two-file environment strategy and ensures consistent naming conventions for optional stats command services.