### PR TITLE
refactor: extract StravaConsole into focused sub-components

### DIFF
--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -2,57 +2,19 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import {
-  Box,
-  VStack,
-  HStack,
-  Heading,
-  Text,
-  Button,
-  Icon,
-  Flex,
-  Spinner,
-  Badge,
-  Collapsible,
-  NativeSelectRoot,
-  NativeSelectField,
-  Input
-} from '@chakra-ui/react';
-import {
-  MdTerminal,
-  MdPlayArrow,
-  MdStop,
-  MdDownload,
-  MdDelete,
-  MdRefresh,
-  MdExpandMore,
-  MdExpandLess,
-  MdWarning,
-  MdCheckCircle,
-  MdHelp,
-  MdSearch,
-  MdVerticalAlignBottom
-} from 'react-icons/md';
-import StravaConsoleTerminal from './strava-console/StravaConsoleTerminal';
+import { Box, VStack, Collapsible } from '@chakra-ui/react';
 import CommandHistoryPanel from './strava-console/CommandHistoryPanel';
 import DiscoverCommandsDialog from './strava-console/DiscoverCommandsDialog';
+import ConsoleDisabledView from './strava-console/ConsoleDisabledView';
+import WarningBanner from './strava-console/WarningBanner';
+import RunnerOfflineAlert from './strava-console/RunnerOfflineAlert';
+import ErrorAlert from './strava-console/ErrorAlert';
+import ConsoleHeader from './strava-console/ConsoleHeader';
+import CommandSelectionCard from './strava-console/CommandSelectionCard';
+import TerminalPanel from './strava-console/TerminalPanel';
 import { useStravaConsole } from './hooks/useStravaConsole';
 import { useCommandHistory } from './hooks/useCommandHistory';
 import { useSettings } from '../../../src/state/SettingsProvider';
-
-/**
- * Format elapsed milliseconds as H:MM:SS or M:SS
- */
-function formatElapsedTime(ms) {
-  const totalSeconds = Math.floor(ms / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-  }
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
 
 export default function StravaConsole() {
   const searchParams = useSearchParams();
@@ -60,7 +22,6 @@ export default function StravaConsole() {
   const terminalRef = useRef(null);
   const [showHistory, setShowHistory] = useState(false);
   const [terminalReady, setTerminalReady] = useState(false);
-  const [autoScroll, setAutoScroll] = useState(true);
   const [args, setArgs] = useState('');
   const [argsError, setArgsError] = useState('');
 
@@ -87,7 +48,8 @@ export default function StravaConsole() {
     // Elapsed time
     elapsedMs,
     // Auto-scroll
-    setAutoScroll: hookSetAutoScroll,
+    autoScroll,
+    setAutoScroll,
     // Discovery
     isDiscovering,
     discoveredCommands,
@@ -179,10 +141,8 @@ export default function StravaConsole() {
 
   // Handle auto-scroll toggle
   const handleAutoScrollToggle = useCallback(() => {
-    const newVal = !autoScroll;
-    setAutoScroll(newVal);
-    hookSetAutoScroll(newVal);
-  }, [autoScroll, hookSetAutoScroll]);
+    setAutoScroll(!autoScroll);
+  }, [autoScroll, setAutoScroll]);
 
   // Handle discover
   const handleDiscover = useCallback(() => {
@@ -244,452 +204,70 @@ export default function StravaConsole() {
 
   // Show disabled state if feature is not enabled
   if (!isFeatureEnabled) {
-    return (
-      <Box p={6} minH="100vh" bg="bg">
-        <VStack align="stretch" gap={6} maxW="1400px" mx="auto">
-          <HStack gap={3}>
-            <Icon as={MdTerminal} boxSize={7} color="fg.muted" />
-            <Heading as="h2" size="xl" color="text">
-              SFS Console
-            </Heading>
-          </HStack>
-
-          <Box
-            p={6}
-            bg="cardBg"
-            borderRadius="lg"
-            border="1px solid"
-            borderColor="border"
-          >
-            <VStack gap={4} align="center" py={8}>
-              <Icon as={MdTerminal} boxSize={12} color="fg.muted" />
-              <Heading size="md" color="text">SFS Console is Disabled</Heading>
-              <Text color="fg.muted" textAlign="center" maxW="500px">
-                The SFS Console allows you to execute Statistics for Strava commands
-                via the Strava Runner sidecar service.
-              </Text>
-              <VStack align="start" gap={2} mt={4}>
-                <Text color="fg.muted" fontWeight="medium">To enable this feature:</Text>
-                <Text color="fg.muted" fontSize="sm">
-                  1. Enable the Strava Runner sidecar in your docker-compose.yml
-                </Text>
-                <Text color="fg.muted" fontSize="sm">
-                  2. Go to Settings and toggle "Enable SFS Console"
-                </Text>
-              </VStack>
-              <HStack gap={3} mt={4}>
-                <Button
-                  as="a"
-                  href="/docs/sfs-console"
-                  colorPalette="blue"
-                  variant="outline"
-                  size="sm"
-                >
-                  <Icon as={MdHelp} mr={2} />
-                  View Documentation
-                </Button>
-              </HStack>
-            </VStack>
-          </Box>
-        </VStack>
-      </Box>
-    );
+    return <ConsoleDisabledView />;
   }
 
   return (
     <Box p={{ base: 3, sm: 4, md: 6 }} minH="100vh" bg="bg">
       {/* Warning Banner - Command Running */}
       {isRunning && (
-        <Box
-          position="fixed"
-          top={0}
-          left={0}
-          right={0}
-          bg="orange.500"
-          color="white"
-          py={2}
-          px={{ base: 2, sm: 4 }}
-          textAlign="center"
-          zIndex={9999}
-          fontWeight="bold"
-          boxShadow="lg"
-        >
-          <HStack justify="center" gap={{ base: 1, sm: 2 }}>
-            <Icon as={MdWarning} boxSize={{ base: 4, sm: 5 }} />
-            <Text fontSize={{ base: "xs", sm: "sm" }} display={{ base: "none", sm: "block" }}>
-              Command Running - Do Not Close This Page or Navigate Away
-            </Text>
-            <Text fontSize="xs" display={{ base: "block", sm: "none" }}>
-              Command Running - Don't Navigate Away
-            </Text>
-            <Icon as={MdWarning} boxSize={{ base: 4, sm: 5 }} />
-          </HStack>
-        </Box>
+        <WarningBanner
+          message="Command Running - Do Not Close This Page or Navigate Away"
+          shortMessage="Command Running - Don't Navigate Away"
+        />
       )}
 
       <VStack align="stretch" gap={{ base: 4, sm: 5, md: 6 }} maxW="1400px" mx="auto" mt={isRunning ? 12 : 0}>
         {/* Header */}
-        <Flex justify="space-between" align={{ base: "flex-start", sm: "center" }} direction={{ base: "column", sm: "row" }} wrap="wrap" gap={4}>
-          <HStack gap={{ base: 2, sm: 3 }}>
-            <Icon as={MdTerminal} boxSize={{ base: 6, sm: 7 }} color="primary" />
-            <Heading as="h2" size={{ base: "md", sm: "lg", md: "xl" }} color="text">
-              Statistics for Strava Console
-            </Heading>
-          </HStack>
-          <HStack gap={2} flexWrap="wrap" w={{ base: "100%", sm: "auto" }}>
-            {/* Runner Status Badge */}
-            {runnerStatus === 'online' && (
-              <Badge colorPalette="green" variant="solid" size="sm">
-                <HStack gap={1}>
-                  <Icon as={MdCheckCircle} boxSize={3} />
-                  <Text>Runner Connected</Text>
-                </HStack>
-              </Badge>
-            )}
-            {runnerStatus === 'checking' && (
-              <Badge colorPalette="gray" variant="solid" size="sm">
-                <HStack gap={1}>
-                  <Spinner size="xs" />
-                  <Text>Checking...</Text>
-                </HStack>
-              </Badge>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowHistory(!showHistory)}
-              color="text"
-              borderColor="border"
-              w={{ base: "100%", sm: "auto" }}
-            >
-              <Icon as={showHistory ? MdExpandLess : MdExpandMore} mr={2} />
-              <Text display={{ base: "none", sm: "inline" }}>
-                {showHistory ? 'Hide History' : 'Show History'}
-              </Text>
-              <Text display={{ base: "inline", sm: "none" }}>
-                History
-              </Text>
-              {history.length > 0 && (
-                <Badge ml={2} colorPalette="blue" variant="solid" size="sm">
-                  {history.length}
-                </Badge>
-              )}
-            </Button>
-          </HStack>
-        </Flex>
-
-        <Text color="textMuted" fontSize="md">
-          Execute Statistics for Strava console commands and view real-time output.
-          Commands run inside the Strava Runner container.
-        </Text>
+        <ConsoleHeader
+          runnerStatus={runnerStatus}
+          showHistory={showHistory}
+          onToggleHistory={() => setShowHistory(!showHistory)}
+          historyCount={history.length}
+        />
 
         {/* Runner Offline Warning */}
         {runnerStatus === 'offline' && (
-          <Box
-            p={4}
-            bg="orange.50"
-            borderRadius="md"
-            border="1px solid"
-            borderColor="orange.200"
-            _dark={{ bg: 'rgba(251, 146, 60, 0.1)', borderColor: 'orange.700' }}
-          >
-
-            <Flex gap={3} align="flex-start">
-              <Icon as={MdWarning} color="orange.500" boxSize={5} mt={0.5} />
-              <VStack align="start" gap={1} flex={1}>
-                <Text fontWeight="medium" color="orange.700" _dark={{ color: 'orange.200' }}>
-                  Strava Runner Offline
-                </Text>
-                <Text fontSize="sm" color="orange.600" _dark={{ color: 'orange.300' }}>
-                  The Strava Runner sidecar is not responding. Make sure it's enabled in your
-                  docker-compose.yml and running. The Run button is disabled until the runner is available.
-                </Text>
-              </VStack>
-              <Button
-                size="sm"
-                variant="outline"
-                colorPalette="orange"
-                onClick={checkRunnerHealth}
-              >
-                <Icon as={MdRefresh} mr={1} />
-                Retry
-              </Button>
-            </Flex>
-          </Box>
+          <RunnerOfflineAlert onRetry={checkRunnerHealth} />
         )}
 
         {/* Error display */}
-        {error && (
-          <Box
-            p={4}
-            bg="red.50"
-            borderRadius="md"
-            border="1px solid"
-            borderColor="red.200"
-            _dark={{ bg: 'rgba(239, 68, 68, 0.1)', borderColor: 'red.700' }}
-          >
-
-            <Text color="red.600" _dark={{ color: 'red.200' }}>
-              {error}
-            </Text>
-          </Box>
-        )}
+        <ErrorAlert message={error} />
 
         {/* Command Selection Card */}
-        <Box
-          p={{ base: 4, sm: 5 }}
-          bg="cardBg"
-          borderRadius="lg"
-          border="1px solid"
-          borderColor="border"
-        >
-          <VStack align="stretch" gap={3}>
-            {/* Command Row with Buttons */}
-            <Box>
-              <Text fontSize="sm" fontWeight="medium" color="text" mb={2}>
-                Command
-              </Text>
-              {isLoadingCommands ? (
-                <HStack gap={2} h="40px" align="center">
-                  <Spinner size="sm" color="primary" />
-                  <Text fontSize="sm" color="textMuted">Loading commands...</Text>
-                </HStack>
-              ) : (
-                <Flex gap={2} wrap="wrap" align="center">
-                  <Box flex="1" minW={{ base: "100%", sm: "200px" }}>
-                    <NativeSelectRoot>
-                      <NativeSelectField
-                        value={selectedCommandId || ''}
-                        onChange={(e) => selectCommand(e.target.value)}
-                        disabled={isRunning}
-                        placeholder="Select a command"
-                      >
-                        {commands.map((cmd) => (
-                          <option key={cmd.id} value={cmd.id}>
-                            {cmd.name}
-                          </option>
-                        ))}
-                      </NativeSelectField>
-                    </NativeSelectRoot>
-                  </Box>
-
-                  {/* Action Buttons */}
-                  {!isRunning ? (
-                    <Button
-                      colorPalette="green"
-                      onClick={handleRun}
-                      disabled={!selectedCommand || !terminalReady || runnerStatus !== 'online'}
-                      size="sm"
-                      title="Run command"
-                    >
-                      <Icon as={MdPlayArrow} />
-                      <Text display={{ base: "none", sm: "inline" }} ml={1}>Run</Text>
-                    </Button>
-                  ) : (
-                    <Button
-                      colorPalette="red"
-                      onClick={stopCommand}
-                      size="sm"
-                      title="Stop command"
-                    >
-                      <Icon as={MdStop} />
-                      <Text display={{ base: "none", sm: "inline" }} ml={1}>Stop</Text>
-                    </Button>
-                  )}
-
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={reloadCommands}
-                    disabled={isRunning}
-                    title="Reload commands"
-                    color="text"
-                    borderColor="border"
-                  >
-                    <Icon as={MdRefresh} />
-                    <Text display={{ base: "none", sm: "inline" }} ml={1}>Reload</Text>
-                  </Button>
-
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDiscover}
-                    disabled={isRunning || isDiscovering || runnerStatus !== 'online'}
-                    title="Discover commands from the Strava container"
-                    color="text"
-                    borderColor="border"
-                  >
-                    {isDiscovering ? <Spinner size="xs" /> : <Icon as={MdSearch} />}
-                    <Text display={{ base: "none", sm: "inline" }} ml={1}>Discover</Text>
-                  </Button>
-                </Flex>
-              )}
-            </Box>
-
-            {/* Command Info */}
-            {selectedCommand && (
-              <Box 
-                p={3} 
-                bg="gray.50" 
-                _dark={{ bg: 'gray.800', borderColor: 'gray.700' }} 
-                borderRadius="md"
-                border="1px solid"
-                borderColor="gray.200"
-              >
-                <VStack align="stretch" gap={1}>
-                  <Text fontSize="xs" color="gray.700" _dark={{ color: 'gray.200' }}>
-                    {selectedCommand.description}
-                  </Text>
-                  <Text fontSize="xs" color="gray.600" _dark={{ color: 'gray.300' }} fontFamily="mono" wordBreak="break-word">
-                    php bin/console {selectedCommand.command}
-                  </Text>
-                </VStack>
-              </Box>
-            )}
-
-            {/* Arguments Input - Show when command accepts args */}
-            {selectedCommand?.acceptsArgs && (
-              <Box mt={3}>
-                <Text fontSize="sm" fontWeight="medium" color="text" mb={2}>
-                  Arguments {selectedCommand.argsDescription && (
-                    <Text as="span" fontWeight="normal" color="textMuted">
-                      — {selectedCommand.argsDescription}
-                    </Text>
-                  )}
-                </Text>
-                <VStack align="stretch" gap={2}>
-                  <Input
-                    value={args}
-                    onChange={(e) => {
-                      setArgs(e.target.value);
-                      setArgsError('');
-                    }}
-                    placeholder={selectedCommand.argsPlaceholder || 'Enter arguments'}
-                    disabled={isRunning}
-                    fontFamily="mono"
-                    fontSize="sm"
-                    borderColor={argsError ? 'red.500' : 'border'}
-                    _focus={{
-                      borderColor: argsError ? 'red.500' : 'blue.500',
-                      boxShadow: argsError ? '0 0 0 1px var(--chakra-colors-red-500)' : '0 0 0 1px var(--chakra-colors-blue-500)'
-                    }}
-                  />
-                  {argsError && (
-                    <Text fontSize="sm" color="red.500">
-                      {argsError}
-                    </Text>
-                  )}
-                </VStack>
-              </Box>
-            )}
-          </VStack>
-        </Box>
+        <CommandSelectionCard
+          commands={commands}
+          selectedCommandId={selectedCommandId}
+          selectedCommand={selectedCommand}
+          isRunning={isRunning}
+          isLoadingCommands={isLoadingCommands}
+          isDiscovering={isDiscovering}
+          runnerStatus={runnerStatus}
+          terminalReady={terminalReady}
+          args={args}
+          argsError={argsError}
+          onSelectCommand={selectCommand}
+          onRun={handleRun}
+          onStop={stopCommand}
+          onReload={reloadCommands}
+          onDiscover={handleDiscover}
+          onArgsChange={setArgs}
+          onArgsErrorClear={() => setArgsError('')}
+        />
 
         {/* Terminal */}
-        <Box
-          bg="cardBg"
-          borderRadius="lg"
-          border="1px solid"
-          borderColor="border"
-          overflow="hidden"
-        >
-          <Flex
-            px={{ base: 3, sm: 4 }}
-            py={3}
-            bg="panelBg"
-            borderBottom="1px solid"
-            borderColor="border"
-            justify="space-between"
-            align="center"
-            direction={{ base: "column", sm: "row" }}
-            gap={{ base: 2, sm: 0 }}
-          >
-            <HStack gap={2} flexWrap="wrap" w={{ base: "100%", sm: "auto" }}>
-              <Icon as={MdTerminal} color="text" />
-              <Text fontSize="sm" fontWeight="medium" color="text">
-                Terminal Output
-              </Text>
-              {/* Connection State Badges */}
-              {connectionState === 'running' && (
-                <Badge colorPalette="green" variant="solid" size="sm">
-                  <HStack gap={1}>
-                    <Spinner size="xs" />
-                    <Text>Running</Text>
-                  </HStack>
-                </Badge>
-              )}
-              {connectionState === 'streaming' && (
-                <Badge colorPalette="blue" variant="solid" size="sm">
-                  <HStack gap={1}>
-                    <Spinner size="xs" />
-                    <Text>Streaming</Text>
-                  </HStack>
-                </Badge>
-              )}
-              {connectionState === 'completed' && (
-                <Badge colorPalette="green" variant="subtle" size="sm">
-                  Completed
-                </Badge>
-              )}
-              {connectionState === 'error' && (
-                <Badge colorPalette="red" variant="subtle" size="sm">
-                  Error
-                </Badge>
-              )}
-              {connectionState === 'disconnected' && (
-                <Badge colorPalette="orange" variant="subtle" size="sm">
-                  Disconnected
-                </Badge>
-              )}
-              {/* Elapsed Time */}
-              {isRunning && (
-                <Text fontSize="xs" color="textMuted" fontFamily="mono" ml={2}>
-                  {formatElapsedTime(elapsedMs)}
-                </Text>
-              )}
-            </HStack>
-            <HStack gap={2} w={{ base: "100%", sm: "auto" }} justify={{ base: "flex-end", sm: "flex-start" }}>
-              {/* Auto-scroll toggle */}
-              <Button
-                size="xs"
-                variant={autoScroll ? 'solid' : 'ghost'}
-                colorPalette={autoScroll ? 'blue' : 'gray'}
-                onClick={handleAutoScrollToggle}
-                title={autoScroll ? 'Auto-scroll enabled' : 'Auto-scroll disabled'}
-              >
-                <Icon as={MdVerticalAlignBottom} />
-                <Text display={{ base: "none", sm: "inline" }} ml={1}>Auto-scroll</Text>
-              </Button>
-              {lastLogPath && (
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  onClick={handleDownload}
-                  color="text"
-                  title="Download Log"
-                >
-                  <Icon as={MdDownload} />
-                  <Text display={{ base: "none", sm: "inline" }} ml={1}>Download</Text>
-                </Button>
-              )}
-              <Button
-                size="xs"
-                variant="ghost"
-                onClick={clearTerminal}
-                disabled={isRunning}
-                color="text"
-                title="Clear"
-              >
-                <Icon as={MdDelete} />
-                <Text display={{ base: "none", sm: "inline" }} ml={1}>Clear</Text>
-              </Button>
-            </HStack>
-          </Flex>
-          <StravaConsoleTerminal
-            ref={terminalRef}
-            onReady={handleTerminalReady}
-          />
-        </Box>
+        <TerminalPanel
+          ref={terminalRef}
+          connectionState={connectionState}
+          isRunning={isRunning}
+          elapsedMs={elapsedMs}
+          autoScroll={autoScroll}
+          lastLogPath={lastLogPath}
+          onAutoScrollToggle={handleAutoScrollToggle}
+          onDownload={handleDownload}
+          onClear={clearTerminal}
+          onTerminalReady={handleTerminalReady}
+        />
 
         {/* Command History Panel */}
         <Collapsible.Root open={showHistory}>

--- a/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
+++ b/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
@@ -30,26 +30,7 @@ import {
 } from 'react-icons/md';
 import LogManagementDialog from './LogManagementDialog';
 import { ConfirmDialog } from '../../../_components/ui/ConfirmDialog';
-
-/**
- * Format timestamp to relative time
- */
-function formatRelativeTime(timestamp) {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffInMinutes = Math.floor((now - date) / 60000);
-
-  if (diffInMinutes < 1) return 'Just now';
-  if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
-
-  const diffInHours = Math.floor(diffInMinutes / 60);
-  if (diffInHours < 24) return `${diffInHours}h ago`;
-
-  const diffInDays = Math.floor(diffInHours / 24);
-  if (diffInDays < 7) return `${diffInDays}d ago`;
-
-  return date.toLocaleDateString();
-}
+import { formatRelativeTime } from './utils/formatters';
 
 /**
  * Get status badge props

--- a/app/utilities/_components/strava-console/CommandSelectionCard.jsx
+++ b/app/utilities/_components/strava-console/CommandSelectionCard.jsx
@@ -1,0 +1,195 @@
+'use client';
+
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Button,
+  Icon,
+  Flex,
+  Spinner,
+  NativeSelectRoot,
+  NativeSelectField,
+  Input
+} from '@chakra-ui/react';
+import {
+  MdPlayArrow,
+  MdStop,
+  MdRefresh,
+  MdSearch
+} from 'react-icons/md';
+
+/**
+ * Card containing command selection dropdown, action buttons, and arguments input
+ */
+export default function CommandSelectionCard({
+  commands,
+  selectedCommandId,
+  selectedCommand,
+  isRunning,
+  isLoadingCommands,
+  isDiscovering,
+  runnerStatus,
+  terminalReady,
+  args,
+  argsError,
+  onSelectCommand,
+  onRun,
+  onStop,
+  onReload,
+  onDiscover,
+  onArgsChange,
+  onArgsErrorClear
+}) {
+  return (
+    <Box
+      p={{ base: 4, sm: 5 }}
+      bg="cardBg"
+      borderRadius="lg"
+      border="1px solid"
+      borderColor="border"
+    >
+      <VStack align="stretch" gap={3}>
+        {/* Command Row with Buttons */}
+        <Box>
+          <Text fontSize="sm" fontWeight="medium" color="text" mb={2}>
+            Command
+          </Text>
+          {isLoadingCommands ? (
+            <HStack gap={2} h="40px" align="center">
+              <Spinner size="sm" color="primary" />
+              <Text fontSize="sm" color="textMuted">Loading commands...</Text>
+            </HStack>
+          ) : (
+            <Flex gap={2} wrap="wrap" align="center">
+              <Box flex="1" minW={{ base: "100%", sm: "200px" }}>
+                <NativeSelectRoot>
+                  <NativeSelectField
+                    value={selectedCommandId || ''}
+                    onChange={(e) => onSelectCommand(e.target.value)}
+                    disabled={isRunning}
+                    placeholder="Select a command"
+                  >
+                    {commands.map((cmd) => (
+                      <option key={cmd.id} value={cmd.id}>
+                        {cmd.name}
+                      </option>
+                    ))}
+                  </NativeSelectField>
+                </NativeSelectRoot>
+              </Box>
+
+              {/* Action Buttons */}
+              {!isRunning ? (
+                <Button
+                  colorPalette="green"
+                  onClick={onRun}
+                  disabled={!selectedCommand || !terminalReady || runnerStatus !== 'online'}
+                  size="sm"
+                  title="Run command"
+                >
+                  <Icon as={MdPlayArrow} />
+                  <Text display={{ base: "none", sm: "inline" }} ml={1}>Run</Text>
+                </Button>
+              ) : (
+                <Button
+                  colorPalette="red"
+                  onClick={onStop}
+                  size="sm"
+                  title="Stop command"
+                >
+                  <Icon as={MdStop} />
+                  <Text display={{ base: "none", sm: "inline" }} ml={1}>Stop</Text>
+                </Button>
+              )}
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onReload}
+                disabled={isRunning}
+                title="Reload commands"
+                color="text"
+                borderColor="border"
+              >
+                <Icon as={MdRefresh} />
+                <Text display={{ base: "none", sm: "inline" }} ml={1}>Reload</Text>
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onDiscover}
+                disabled={isRunning || isDiscovering || runnerStatus !== 'online'}
+                title="Discover commands from the Strava container"
+                color="text"
+                borderColor="border"
+              >
+                {isDiscovering ? <Spinner size="xs" /> : <Icon as={MdSearch} />}
+                <Text display={{ base: "none", sm: "inline" }} ml={1}>Discover</Text>
+              </Button>
+            </Flex>
+          )}
+        </Box>
+
+        {/* Command Info */}
+        {selectedCommand && (
+          <Box
+            p={3}
+            bg="gray.50"
+            _dark={{ bg: 'gray.800', borderColor: 'gray.700' }}
+            borderRadius="md"
+            border="1px solid"
+            borderColor="gray.200"
+          >
+            <VStack align="stretch" gap={1}>
+              <Text fontSize="xs" color="gray.700" _dark={{ color: 'gray.200' }}>
+                {selectedCommand.description}
+              </Text>
+              <Text fontSize="xs" color="gray.600" _dark={{ color: 'gray.300' }} fontFamily="mono" wordBreak="break-word">
+                php bin/console {selectedCommand.command}
+              </Text>
+            </VStack>
+          </Box>
+        )}
+
+        {/* Arguments Input - Show when command accepts args */}
+        {selectedCommand?.acceptsArgs && (
+          <Box mt={3}>
+            <Text fontSize="sm" fontWeight="medium" color="text" mb={2}>
+              Arguments {selectedCommand.argsDescription && (
+                <Text as="span" fontWeight="normal" color="textMuted">
+                  — {selectedCommand.argsDescription}
+                </Text>
+              )}
+            </Text>
+            <VStack align="stretch" gap={2}>
+              <Input
+                value={args}
+                onChange={(e) => {
+                  onArgsChange(e.target.value);
+                  onArgsErrorClear();
+                }}
+                placeholder={selectedCommand.argsPlaceholder || 'Enter arguments'}
+                disabled={isRunning}
+                fontFamily="mono"
+                fontSize="sm"
+                borderColor={argsError ? 'red.500' : 'border'}
+                _focus={{
+                  borderColor: argsError ? 'red.500' : 'blue.500',
+                  boxShadow: argsError ? '0 0 0 1px var(--chakra-colors-red-500)' : '0 0 0 1px var(--chakra-colors-blue-500)'
+                }}
+              />
+              {argsError && (
+                <Text fontSize="sm" color="red.500">
+                  {argsError}
+                </Text>
+              )}
+            </VStack>
+          </Box>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/ConnectionStateBadge.jsx
+++ b/app/utilities/_components/strava-console/ConnectionStateBadge.jsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Badge, HStack, Text, Spinner } from '@chakra-ui/react';
+
+const BADGE_CONFIG = {
+  running: { colorPalette: 'green', variant: 'solid', label: 'Running', showSpinner: true },
+  streaming: { colorPalette: 'blue', variant: 'solid', label: 'Streaming', showSpinner: true },
+  completed: { colorPalette: 'green', variant: 'subtle', label: 'Completed', showSpinner: false },
+  error: { colorPalette: 'red', variant: 'subtle', label: 'Error', showSpinner: false },
+  disconnected: { colorPalette: 'orange', variant: 'subtle', label: 'Disconnected', showSpinner: false }
+};
+
+/**
+ * Badge showing the current connection/execution state
+ * @param {Object} props
+ * @param {string} props.connectionState - 'idle' | 'connecting' | 'running' | 'streaming' | 'completed' | 'error' | 'disconnected'
+ */
+export default function ConnectionStateBadge({ connectionState }) {
+  const config = BADGE_CONFIG[connectionState];
+  if (!config) return null;
+
+  return (
+    <Badge colorPalette={config.colorPalette} variant={config.variant} size="sm">
+      {config.showSpinner ? (
+        <HStack gap={1}>
+          <Spinner size="xs" />
+          <Text>{config.label}</Text>
+        </HStack>
+      ) : (
+        config.label
+      )}
+    </Badge>
+  );
+}

--- a/app/utilities/_components/strava-console/ConsoleDisabledView.jsx
+++ b/app/utilities/_components/strava-console/ConsoleDisabledView.jsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  Box,
+  VStack,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  Icon
+} from '@chakra-ui/react';
+import { MdTerminal, MdHelp } from 'react-icons/md';
+
+/**
+ * Displayed when the SFS Console feature is disabled in settings
+ */
+export default function ConsoleDisabledView() {
+  return (
+    <Box p={6} minH="100vh" bg="bg">
+      <VStack align="stretch" gap={6} maxW="1400px" mx="auto">
+        <HStack gap={3}>
+          <Icon as={MdTerminal} boxSize={7} color="textMuted" />
+          <Heading as="h2" size="xl" color="text">
+            SFS Console
+          </Heading>
+        </HStack>
+
+        <Box
+          p={6}
+          bg="cardBg"
+          borderRadius="lg"
+          border="1px solid"
+          borderColor="border"
+        >
+          <VStack gap={4} align="center" py={8}>
+            <Icon as={MdTerminal} boxSize={12} color="textMuted" />
+            <Heading size="md" color="text">SFS Console is Disabled</Heading>
+            <Text color="textMuted" textAlign="center" maxW="500px">
+              The SFS Console allows you to execute Statistics for Strava commands
+              via the Strava Runner sidecar service.
+            </Text>
+            <VStack align="start" gap={2} mt={4}>
+              <Text color="textMuted" fontWeight="medium">To enable this feature:</Text>
+              <Text color="textMuted" fontSize="sm">
+                1. Enable the Strava Runner sidecar in your docker-compose.yml
+              </Text>
+              <Text color="textMuted" fontSize="sm">
+                2. Go to Settings and toggle "Enable SFS Console"
+              </Text>
+            </VStack>
+            <HStack gap={3} mt={4}>
+              <Button
+                as="a"
+                href="/docs/sfs-console"
+                colorPalette="blue"
+                variant="outline"
+                size="sm"
+              >
+                <Icon as={MdHelp} mr={2} />
+                View Documentation
+              </Button>
+            </HStack>
+          </VStack>
+        </Box>
+      </VStack>
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/ConsoleHeader.jsx
+++ b/app/utilities/_components/strava-console/ConsoleHeader.jsx
@@ -1,0 +1,76 @@
+'use client';
+
+import {
+  Flex,
+  HStack,
+  Heading,
+  Text,
+  Button,
+  Icon,
+  Badge
+} from '@chakra-ui/react';
+import { MdTerminal, MdExpandMore, MdExpandLess } from 'react-icons/md';
+import RunnerStatusBadge from './RunnerStatusBadge';
+
+/**
+ * Header section of the console with title, runner status, and history toggle
+ * @param {Object} props
+ * @param {string} props.runnerStatus - 'online' | 'offline' | 'checking' | 'unknown'
+ * @param {boolean} props.showHistory - Whether history panel is visible
+ * @param {Function} props.onToggleHistory - Callback to toggle history panel
+ * @param {number} props.historyCount - Number of items in history
+ */
+export default function ConsoleHeader({
+  runnerStatus,
+  showHistory,
+  onToggleHistory,
+  historyCount
+}) {
+  return (
+    <>
+      <Flex
+        justify="space-between"
+        align={{ base: "flex-start", sm: "center" }}
+        direction={{ base: "column", sm: "row" }}
+        wrap="wrap"
+        gap={4}
+      >
+        <HStack gap={{ base: 2, sm: 3 }}>
+          <Icon as={MdTerminal} boxSize={{ base: 6, sm: 7 }} color="primary" />
+          <Heading as="h2" size={{ base: "md", sm: "lg", md: "xl" }} color="text">
+            Statistics for Strava Console
+          </Heading>
+        </HStack>
+        <HStack gap={2} flexWrap="wrap" w={{ base: "100%", sm: "auto" }}>
+          <RunnerStatusBadge status={runnerStatus} />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onToggleHistory}
+            color="text"
+            borderColor="border"
+            w={{ base: "100%", sm: "auto" }}
+          >
+            <Icon as={showHistory ? MdExpandLess : MdExpandMore} mr={2} />
+            <Text display={{ base: "none", sm: "inline" }}>
+              {showHistory ? 'Hide History' : 'Show History'}
+            </Text>
+            <Text display={{ base: "inline", sm: "none" }}>
+              History
+            </Text>
+            {historyCount > 0 && (
+              <Badge ml={2} colorPalette="blue" variant="solid" size="sm">
+                {historyCount}
+              </Badge>
+            )}
+          </Button>
+        </HStack>
+      </Flex>
+
+      <Text color="textMuted" fontSize="md">
+        Execute Statistics for Strava console commands and view real-time output.
+        Commands run inside the Strava Runner container.
+      </Text>
+    </>
+  );
+}

--- a/app/utilities/_components/strava-console/ErrorAlert.jsx
+++ b/app/utilities/_components/strava-console/ErrorAlert.jsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Box, Text } from '@chakra-ui/react';
+
+/**
+ * Alert box for displaying error messages
+ * @param {Object} props
+ * @param {string} props.message - Error message to display
+ */
+export default function ErrorAlert({ message }) {
+  if (!message) return null;
+
+  return (
+    <Box
+      p={4}
+      bg="red.50"
+      borderRadius="md"
+      border="1px solid"
+      borderColor="red.200"
+      _dark={{ bg: 'rgba(239, 68, 68, 0.1)', borderColor: 'red.700' }}
+    >
+      <Text color="red.600" _dark={{ color: 'red.200' }}>
+        {message}
+      </Text>
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/LogManagementDialog.jsx
+++ b/app/utilities/_components/strava-console/LogManagementDialog.jsx
@@ -4,14 +4,7 @@ import { useState } from 'react';
 import { Badge, Icon, Text, Table, HStack, Box, Dialog, Portal, Button, VStack } from '@chakra-ui/react';
 import { MdCheckCircle, MdError, MdClose } from 'react-icons/md';
 import FileManagerDialog from '../common/FileManagerDialog';
-
-function formatBytes(bytes) {
-  if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
-}
+import { formatBytes } from './utils/formatters';
 
 export default function LogManagementDialog({ isOpen, onClose }) {
   const [logCount, setLogCount] = useState(0);

--- a/app/utilities/_components/strava-console/RunnerOfflineAlert.jsx
+++ b/app/utilities/_components/strava-console/RunnerOfflineAlert.jsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Box, Flex, VStack, Text, Button, Icon } from '@chakra-ui/react';
+import { MdWarning, MdRefresh } from 'react-icons/md';
+
+/**
+ * Alert box displayed when the Strava Runner sidecar is offline
+ * @param {Object} props
+ * @param {Function} props.onRetry - Callback to retry connection
+ */
+export default function RunnerOfflineAlert({ onRetry }) {
+  return (
+    <Box
+      p={4}
+      bg="orange.50"
+      borderRadius="md"
+      border="1px solid"
+      borderColor="orange.200"
+      _dark={{ bg: 'rgba(251, 146, 60, 0.1)', borderColor: 'orange.700' }}
+    >
+      <Flex gap={3} align="flex-start">
+        <Icon as={MdWarning} color="orange.500" boxSize={5} mt={0.5} />
+        <VStack align="start" gap={1} flex={1}>
+          <Text fontWeight="medium" color="orange.700" _dark={{ color: 'orange.200' }}>
+            Strava Runner Offline
+          </Text>
+          <Text fontSize="sm" color="orange.600" _dark={{ color: 'orange.300' }}>
+            The Strava Runner sidecar is not responding. Make sure it's enabled in your
+            docker-compose.yml and running. The Run button is disabled until the runner is available.
+          </Text>
+        </VStack>
+        <Button
+          size="sm"
+          variant="outline"
+          colorPalette="orange"
+          onClick={onRetry}
+        >
+          <Icon as={MdRefresh} mr={1} />
+          Retry
+        </Button>
+      </Flex>
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/RunnerStatusBadge.jsx
+++ b/app/utilities/_components/strava-console/RunnerStatusBadge.jsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Badge, HStack, Icon, Text, Spinner } from '@chakra-ui/react';
+import { MdCheckCircle } from 'react-icons/md';
+
+/**
+ * Badge showing the Strava Runner connection status
+ * @param {Object} props
+ * @param {string} props.status - 'online' | 'offline' | 'checking' | 'unknown'
+ */
+export default function RunnerStatusBadge({ status }) {
+  if (status === 'online') {
+    return (
+      <Badge colorPalette="green" variant="solid" size="sm">
+        <HStack gap={1}>
+          <Icon as={MdCheckCircle} boxSize={3} />
+          <Text>Runner Connected</Text>
+        </HStack>
+      </Badge>
+    );
+  }
+
+  if (status === 'checking') {
+    return (
+      <Badge colorPalette="gray" variant="solid" size="sm">
+        <HStack gap={1}>
+          <Spinner size="xs" />
+          <Text>Checking...</Text>
+        </HStack>
+      </Badge>
+    );
+  }
+
+  // Don't render for 'offline' or 'unknown' - those have separate UI
+  return null;
+}

--- a/app/utilities/_components/strava-console/TerminalPanel.jsx
+++ b/app/utilities/_components/strava-console/TerminalPanel.jsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { forwardRef } from 'react';
+import {
+  Box,
+  Flex,
+  HStack,
+  Text,
+  Button,
+  Icon
+} from '@chakra-ui/react';
+import {
+  MdTerminal,
+  MdVerticalAlignBottom,
+  MdDownload,
+  MdDelete
+} from 'react-icons/md';
+import ConnectionStateBadge from './ConnectionStateBadge';
+import StravaConsoleTerminal from './StravaConsoleTerminal';
+import { formatElapsedTime } from './utils/formatters';
+
+/**
+ * Terminal panel with header toolbar and output display
+ */
+const TerminalPanel = forwardRef(function TerminalPanel({
+  connectionState,
+  isRunning,
+  elapsedMs,
+  autoScroll,
+  lastLogPath,
+  onAutoScrollToggle,
+  onDownload,
+  onClear,
+  onTerminalReady
+}, ref) {
+  return (
+    <Box
+      bg="cardBg"
+      borderRadius="lg"
+      border="1px solid"
+      borderColor="border"
+      overflow="hidden"
+    >
+      <Flex
+        px={{ base: 3, sm: 4 }}
+        py={3}
+        bg="panelBg"
+        borderBottom="1px solid"
+        borderColor="border"
+        justify="space-between"
+        align="center"
+        direction={{ base: "column", sm: "row" }}
+        gap={{ base: 2, sm: 0 }}
+      >
+        <HStack gap={2} flexWrap="wrap" w={{ base: "100%", sm: "auto" }}>
+          <Icon as={MdTerminal} color="text" />
+          <Text fontSize="sm" fontWeight="medium" color="text">
+            Terminal Output
+          </Text>
+          {/* Connection State Badge */}
+          <ConnectionStateBadge connectionState={connectionState} />
+          {/* Elapsed Time */}
+          {isRunning && (
+            <Text fontSize="xs" color="textMuted" fontFamily="mono" ml={2}>
+              {formatElapsedTime(elapsedMs)}
+            </Text>
+          )}
+        </HStack>
+        <HStack gap={2} w={{ base: "100%", sm: "auto" }} justify={{ base: "flex-end", sm: "flex-start" }}>
+          {/* Auto-scroll toggle */}
+          <Button
+            size="xs"
+            variant={autoScroll ? 'solid' : 'ghost'}
+            colorPalette={autoScroll ? 'blue' : 'gray'}
+            onClick={onAutoScrollToggle}
+            title={autoScroll ? 'Auto-scroll enabled' : 'Auto-scroll disabled'}
+          >
+            <Icon as={MdVerticalAlignBottom} />
+            <Text display={{ base: "none", sm: "inline" }} ml={1}>Auto-scroll</Text>
+          </Button>
+          {lastLogPath && (
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={onDownload}
+              color="text"
+              title="Download Log"
+            >
+              <Icon as={MdDownload} />
+              <Text display={{ base: "none", sm: "inline" }} ml={1}>Download</Text>
+            </Button>
+          )}
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={onClear}
+            disabled={isRunning}
+            color="text"
+            title="Clear"
+          >
+            <Icon as={MdDelete} />
+            <Text display={{ base: "none", sm: "inline" }} ml={1}>Clear</Text>
+          </Button>
+        </HStack>
+      </Flex>
+      <StravaConsoleTerminal
+        ref={ref}
+        onReady={onTerminalReady}
+      />
+    </Box>
+  );
+});
+
+export default TerminalPanel;

--- a/app/utilities/_components/strava-console/WarningBanner.jsx
+++ b/app/utilities/_components/strava-console/WarningBanner.jsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Box, HStack, Text, Icon } from '@chakra-ui/react';
+import { MdWarning } from 'react-icons/md';
+
+/**
+ * Fixed warning banner displayed when a command is running
+ * @param {Object} props
+ * @param {string} props.message - Full message for larger screens
+ * @param {string} props.shortMessage - Shortened message for mobile
+ */
+export default function WarningBanner({ message, shortMessage }) {
+  return (
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      bg="orange.500"
+      color="white"
+      py={2}
+      px={{ base: 2, sm: 4 }}
+      textAlign="center"
+      zIndex={9999}
+      fontWeight="bold"
+      boxShadow="lg"
+    >
+      <HStack justify="center" gap={{ base: 1, sm: 2 }}>
+        <Icon as={MdWarning} boxSize={{ base: 4, sm: 5 }} />
+        <Text fontSize={{ base: "xs", sm: "sm" }} display={{ base: "none", sm: "block" }}>
+          {message}
+        </Text>
+        <Text fontSize="xs" display={{ base: "block", sm: "none" }}>
+          {shortMessage}
+        </Text>
+        <Icon as={MdWarning} boxSize={{ base: 4, sm: 5 }} />
+      </HStack>
+    </Box>
+  );
+}

--- a/app/utilities/_components/strava-console/utils/formatters.js
+++ b/app/utilities/_components/strava-console/utils/formatters.js
@@ -1,0 +1,54 @@
+/**
+ * Utility formatters for the Strava Console
+ */
+
+/**
+ * Format elapsed milliseconds as H:MM:SS or M:SS
+ * @param {number} ms - Elapsed time in milliseconds
+ * @returns {string} Formatted time string
+ */
+export function formatElapsedTime(ms) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/**
+ * Format timestamp to relative time (e.g., "5m ago", "2h ago")
+ * @param {number} timestamp - Unix timestamp in milliseconds
+ * @returns {string} Relative time string
+ */
+export function formatRelativeTime(timestamp) {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffInMinutes = Math.floor((now - date) / 60000);
+
+  if (diffInMinutes < 1) return 'Just now';
+  if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
+
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) return `${diffInHours}h ago`;
+
+  const diffInDays = Math.floor(diffInHours / 24);
+  if (diffInDays < 7) return `${diffInDays}d ago`;
+
+  return date.toLocaleDateString();
+}
+
+/**
+ * Format bytes to human-readable size
+ * @param {number} bytes - Size in bytes
+ * @returns {string} Formatted size string
+ */
+export function formatBytes(bytes) {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
+}


### PR DESCRIPTION
- Extract 10 new components from monolithic StravaConsole.jsx (717 -> 297 lines)
- Create centralized formatters.js utility (formatElapsedTime, formatRelativeTime, formatBytes)
- Fix autoScroll state duplication between component and hook
- Extract mutex error message to helper function in useStravaConsole hook
- New components: ConsoleDisabledView, WarningBanner, RunnerStatusBadge, ConnectionStateBadge, RunnerOfflineAlert, ErrorAlert, ConsoleHeader, CommandSelectionCard, TerminalPanel