### PR TITLE
Add /api/strava-console to public paths for health check

### DIFF
--- a/app/api/strava-console/route.js
+++ b/app/api/strava-console/route.js
@@ -22,10 +22,11 @@ export async function GET() {
 
     if (response.ok) {
       const data = await response.json();
+      // Runner returns { status: 'ok', commandCount, helperUrl, uptime }
       return NextResponse.json({
         success: true,
         status: 'online',
-        ...data
+        runner: data
       });
     }
 

--- a/proxy.js
+++ b/proxy.js
@@ -16,6 +16,7 @@ const publicPaths = [
   '/api/runtime-config',
   '/api/sports-list',
   '/api/file-content',
+  '/api/strava-console', // Health check endpoint for SFS Console runner status
   '/favicon.ico',
 ];
 

--- a/src/hooks/useRunnerHealth.js
+++ b/src/hooks/useRunnerHealth.js
@@ -16,7 +16,7 @@ export function useRunnerHealth() {
     setStatus('checking');
     try {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout (API has 5s timeout)
 
       const response = await fetch('/api/strava-console', {
         signal: controller.signal


### PR DESCRIPTION
The health check endpoint needs to be accessible without authentication since it's called before login to check runner availability in Settings.

Fixes: Health check was redirecting to /login instead of checking runner