### PR TITLE
Fix: Auto-reload history after log deletion

### DIFF
--- a/app/utilities/_components/StravaConsole.jsx
+++ b/app/utilities/_components/StravaConsole.jsx
@@ -63,7 +63,8 @@ export default function StravaConsole() {
     addToHistory,
     updateStatus,
     clearHistory,
-    loadHistoricalCommands
+    loadHistoricalCommands,
+    reloadHistory
   } = useCommandHistory(settings.features?.enableSfsConsole || false);
 
   // Load historical commands on mount
@@ -276,6 +277,7 @@ export default function StravaConsole() {
               history={history}
               onRerun={handleRerun}
               onClear={clearHistory}
+              onReload={reloadHistory}
             />
           </Collapsible.Content>
         </Collapsible.Root>

--- a/app/utilities/_components/common/FileManagerDialog.jsx
+++ b/app/utilities/_components/common/FileManagerDialog.jsx
@@ -48,7 +48,8 @@ export default function FileManagerDialog({
   canView = false,
   downloadUrlGenerator,
   onView = null,
-  onFilesLoaded = null
+  onFilesLoaded = null,
+  onFilesChanged = null
 }) {
   const [files, setFiles] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -123,6 +124,11 @@ export default function FileManagerDialog({
         });
         setSelectedFiles(new Set());
         await loadFiles();
+        
+        // Notify parent that files have changed
+        if (onFilesChanged) {
+          onFilesChanged();
+        }
         
         setTimeout(() => setDeleteResult(null), 3000);
       } else {

--- a/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
+++ b/app/utilities/_components/strava-console/CommandHistoryPanel.jsx
@@ -268,7 +268,7 @@ function HistoryItem({ item, index, totalItems, onRerun }) {
  * Command History Panel
  * Displays a list of previously run commands with their status
  */
-export default function CommandHistoryPanel({ history, onRerun, onClear }) {
+export default function CommandHistoryPanel({ history, onRerun, onClear, onReload }) {
   const [showLogManager, setShowLogManager] = useState(false);
 
   if (history.length === 0) {
@@ -381,6 +381,7 @@ export default function CommandHistoryPanel({ history, onRerun, onClear }) {
       <LogManagementDialog
         isOpen={showLogManager}
         onClose={() => setShowLogManager(false)}
+        onLogsChanged={onReload}
       />
     </Box>
   );

--- a/app/utilities/_components/strava-console/LogManagementDialog.jsx
+++ b/app/utilities/_components/strava-console/LogManagementDialog.jsx
@@ -6,9 +6,16 @@ import { MdCheckCircle, MdError, MdClose } from 'react-icons/md';
 import FileManagerDialog from '../common/FileManagerDialog';
 import { formatBytes } from './utils/formatters';
 
-export default function LogManagementDialog({ isOpen, onClose }) {
+export default function LogManagementDialog({ isOpen, onClose, onLogsChanged }) {
   const [logCount, setLogCount] = useState(0);
   const [viewingLog, setViewingLog] = useState(null);
+
+  const handleLogsChanged = () => {
+    // Notify parent that logs have changed (deleted/modified)
+    if (onLogsChanged) {
+      onLogsChanged();
+    }
+  };
 
   const handleViewLog = async (log) => {
     try {
@@ -106,6 +113,7 @@ export default function LogManagementDialog({ isOpen, onClose }) {
         canView={true}
         onView={handleViewLog}
         onFilesLoaded={(files) => setLogCount(files.length)}
+        onFilesChanged={handleLogsChanged}
         downloadUrlGenerator={(log) => 
           `/api/download-log?path=${encodeURIComponent(log.path)}`
         }


### PR DESCRIPTION
- Add reloadHistory function to useCommandHistory hook
- Pass forceReload parameter to loadHistoricalCommands
- Add onFilesChanged callback to FileManagerDialog
- Wire callback through LogManagementDialog to CommandHistoryPanel
- History now automatically refreshes when logs are deleted
- Fixes issue where deleted logs still appeared until manual refresh