### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "0.10.0",
+  "version": "1.2.0",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.1.0-rc10",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "0.10.0",
+  "version": "1.2.0",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",


### PR DESCRIPTION
Update package versions for v1.2.0 release:
- stats-for-strava-config-tool: 1.1.0-rc10 → 1.2.0
- stats-cmd-runner: 0.10.0 → 1.2.0
- stats-cmd-helper: 0.10.0 → 1.2.0