### PR TITLE
fix: resolve lint errors and React Fast Refresh warnings

### DIFF
--- a/app/(config)/_components/ConfigFileList.jsx
+++ b/app/(config)/_components/ConfigFileList.jsx
@@ -17,7 +17,7 @@ import {
   readFile
 } from '../../../src/services';
 import { useSettings } from '../../../src/state/SettingsProvider';
-import { useConfig } from '../../../src/state/ConfigProvider';
+import { useConfig } from '../../../src/state/useConfig';
 
 const ConfigFileList = forwardRef((props, ref) => {
   // Use contexts

--- a/app/(config)/appearance/page.jsx
+++ b/app/(config)/appearance/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/athlete/page.jsx
+++ b/app/(config)/athlete/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/daemon/page.jsx
+++ b/app/(config)/daemon/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/gear/page.jsx
+++ b/app/(config)/gear/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/general/page.jsx
+++ b/app/(config)/general/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/import/page.jsx
+++ b/app/(config)/import/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/integrations/page.jsx
+++ b/app/(config)/integrations/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/metrics/page.jsx
+++ b/app/(config)/metrics/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/(config)/zwift/page.jsx
+++ b/app/(config)/zwift/page.jsx
@@ -3,7 +3,7 @@
 import { lazy, Suspense, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Box, VStack, Spinner, Text } from '@chakra-ui/react'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 
 // Lazy-load the editor

--- a/app/_components/layout/AppShell.jsx
+++ b/app/_components/layout/AppShell.jsx
@@ -17,7 +17,7 @@ import { useSettings } from '../../../src/state/SettingsProvider'
 import { useDialog } from '../../../src/state/DialogProvider'
 import { useDirtyState } from '../../../src/state/DirtyStateProvider'
 import { useNavigation } from '../../../src/state/NavigationProvider'
-import { useConfig } from '../../../src/state/ConfigProvider'
+import { useConfig } from '../../../src/state/useConfig'
 import { scanConfigFiles, parseSections as parseSectionsService, validateSections as validateSectionsService } from '../../../src/services'
 
 export default function AppShell({ section = 'config', children }) {
@@ -42,6 +42,7 @@ export default function AppShell({ section = 'config', children }) {
       if (
         message.includes('dropdownAlign') ||
         message.includes('popupClassName') ||
+        message.includes('does not recognize the') || // Catches "React does not recognize the `X` prop"
         // Suppress React 19 DevTools hydration instrumentation errors
         message.includes('React instrumentation encountered an error') ||
         message.includes('Offscreen Fiber child in a hydrated Suspense boundary')

--- a/src/state/ConfigProvider.jsx
+++ b/src/state/ConfigProvider.jsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { ConfigContext } from './useConfig';
 import { useConfigData } from '../hooks/useConfigData';
 import { useToast } from '../contexts/ToastContext';
 import { useNavigation } from './NavigationProvider';
 import { useDirtyState } from './DirtyStateProvider';
 import { initializeWidgetDefinitions } from '../utils/widgetDefinitionsInitializer';
 import { initializeSportsList } from '../utils/sportsListInitializer';
-
-const ConfigContext = createContext();
-
-export const useConfig = () => {
-  const context = useContext(ConfigContext);
-  if (!context) {
-    throw new Error('useConfig must be used within a ConfigProvider');
-  }
-  return context;
-};
 
 export const ConfigProvider = ({ children }) => {
   const { showError, showSuccess } = useToast();

--- a/src/state/useConfig.js
+++ b/src/state/useConfig.js
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export const ConfigContext = createContext();
+
+export const useConfig = () => {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error('useConfig must be used within a ConfigProvider');
+  }
+  return context;
+};

--- a/src/utils/widgetDefinitionsInitializer.js
+++ b/src/utils/widgetDefinitionsInitializer.js
@@ -32,6 +32,7 @@ async function widgetDefinitionsFileExists() {
     const result = await readFile(filePath);
     return result.success;
   } catch (error) {
+    console.error('Error checking widget definitions file:', error);
     return false;
   }
 }

--- a/src/utils/widgetDefinitionsManager.js
+++ b/src/utils/widgetDefinitionsManager.js
@@ -426,6 +426,13 @@ metricsDisplayOrder: ['distance', 'movingTime', 'elevation']`,
     allowMultiple: false,
     hasConfig: false
   },
+    'athleteProfile': {
+    name: 'athleteProfile',
+    displayName: 'Athlete Profile',
+    description: 'This widget summarizes how you train. Each axis reflects a different normalized training habit, so higher values mean stronger emphasis.',
+    allowMultiple: false,
+    hasConfig: false
+  },
   'streaks': {
     name: "streaks",
     displayName: "Current streaks",


### PR DESCRIPTION
- Extract ConfigContext and useConfig hook to separate file for Fast Refresh compliance
- Update 11 imports across pages and components to use new useConfig.js export
- Remove unused handleOpenCronDialog and handleCloseCronDialog functions in DaemonConfigEditor
- Wrap cronJobs in useMemo with proper dependencies [formData, getNestedValue]
- Fix handleRemoveCronJob to use functional setState, remove expandedJobs dependency
- Fix handleSaveCronExpression dependencies (remove cronDialogState.jobIndex)
- Add console.error logging in widgetDefinitionsFileExists catch block
- Enhance AppShell error suppression for react-js-cron prop warnings
- Add daemon container restart notice to DaemonConfigEditor info banner
- Add athleteProfile widget definition to widgetDefinitionsManager