### PR TITLE
chore(release): 1.2.2  upgrade next; guard localStorage; add sports; 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+---
+
+## [1.2.2] — 2026-02-22
+
+### Security
+- Upgraded `next` to `16.1.6` to address security advisories affecting earlier versions.
+
+### Changed
+- Replaced direct `localStorage` access with centralized `src/utils/browserStorage.js` helpers to ensure SSR safety.
+- Marked client-only components with the `"use client"` directive where required.
+
+### Added
+- Added default sports to `INITIAL_SPORTS_LIST`: `Basketball`, `Volleyball`, `Cricket`, `Dance`, `Padel`.
+
+### Fixed
+- Resolved server-side ReferenceError caused by `localStorage` usage during build; project builds successfully.
+
+### Misc
+- Ran `npm audit fix` (non-breaking) and applied dependency updates; remaining advisories are in devDependencies.
+
+---
+
 ## [1.2.1] — 2026-01-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "next dev",
@@ -23,7 +23,7 @@
     "framer-motion": "^12.23.26",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
-    "next": "^16.0.10",
+    "next": "^16.1.6",
     "next-themes": "^0.4.6",
     "prop-types": "^15.8.1",
     "react": "^19.2.0",


### PR DESCRIPTION
Security: Upgraded next to 16.1.6 to address security advisories affecting earlier versions.
Changed: Replaced direct localStorage access with centralized src/utils/browserStorage.js helpers to ensure SSR safety. Marked client-only components with the "use client" directive where required.
Added: Added default sports to INITIAL_SPORTS_LIST: Basketball, Volleyball, Cricket, Dance, Padel.
Fixed: Resolved server-side ReferenceError caused by localStorage usage during build; project builds successfully.