### PR TITLE
chore(release): bump version to 1.2.3 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.3] — 2026-03-01
+
+### Added
+- Added optional **Use API Key** checkbox to the AI Provider Configuration section.
+  - When unchecked, the API key field is hidden and the key is saved as blank in YAML (`key: `).
+  - When checked, the API key field is shown and validated as non-empty before saving.
+  - On load, the checkbox auto-checks if an existing key value is present in YAML, and remains unchecked if the key is blank.
+  - The internal `useApiKey` flag is stripped from the output so it never appears in the saved YAML.
+
+---
+
 ## [1.2.2] — 2026-02-22
 
 ### Security

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",


### PR DESCRIPTION
- Updated version to 1.2.3 in package.json, package-lock.json, helper/package.json, and runner/package.json
- Added CHANGELOG entry for 1.2.3 documenting the optional Use API Key checkbox added to the AI Provider Configuration section