### PR TITLE
chore: GitHub issue/PR templates, CONTRIBUTING.md, labels, milestone

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: '[bug] '
+labels: bug, fix
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**Steps to reproduce**
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened.
+
+**Environment**
+- App version:
+- Browser:
+- Docker / local:
+
+**Logs / screenshots**
+Paste any relevant logs or attach screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: '[feat] '
+labels: feat
+assignees: ''
+---
+
+**Problem / motivation**
+What problem does this solve or what need does it address?
+
+**Proposed solution**
+Describe the feature you'd like.
+
+**Alternatives considered**
+Any alternative approaches you've thought about.
+
+**Additional context**
+Any other context, screenshots, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- What does this PR do? 1-3 bullet points -->
+-
+
+## Type of change
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] security — security update
+- [ ] chore — maintenance / dependencies / infra
+- [ ] docker — Docker / deployment
+- [ ] docs — documentation
+
+## Related issue
+Closes #
+
+## Test plan
+<!-- How was this tested? -->
+- [ ]
+
+## Checklist
+- [ ] CHANGELOG.md updated
+- [ ] Version bumped if releasing (package.json in root, runner/, helper/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Branch naming
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/<short-description>` | `feature/add-gear-devices` |
+| Bug fix | `fix/<short-description>` | `fix/login-redirect` |
+| Security | `fix/<cve-or-package>` | `fix/dompurify-xss` |
+| Maintenance | `chore/<short-description>` | `chore/github-project-setup` |
+| Docker/infra | `chore/<short-description>` | `chore/image-optimization` |
+
+## Pull requests
+1. Open an issue first for non-trivial changes
+2. Branch from `main`, keep PRs focused on one thing
+3. Use `Closes #<issue>` in the PR description to auto-close the issue on merge
+4. Update `CHANGELOG.md` under the relevant section for the upcoming version
+5. Bump versions in `package.json` (root, `runner/`, `helper/`) only when cutting a release
+
+## Releases
+Releases are triggered by pushing a version tag:
+```bash
+git tag v1.x.x
+git push origin v1.x.x
+```
+This kicks off the GitHub Actions workflow that builds and publishes Docker images for all three services (config-tool, runner, helper).
+
+## Development setup
+See [README.md](README.md) for installation and local dev instructions.


### PR DESCRIPTION
## Summary
- Add bug report and feature request issue templates under `.github/ISSUE_TEMPLATE/`
- Add PR template (`.github/pull_request_template.md`) with type checklist and CHANGELOG/version reminders
- Add `CONTRIBUTING.md` with branch naming conventions, PR process, and release docs
- Create 5 custom labels: `feat`, `fix`, `security`, `chore`, `docker`
- Create milestone `v1.3.0`

> **Note:** GitHub Project creation requires the `project` token scope, which the current token lacks. See manual step below.

## Type of change
- [x] chore — maintenance / dependencies / infra

## Related issue
N/A

## Test plan
- [ ] Open a new issue — template chooser appears with Bug Report and Feature Request
- [ ] Open a PR — template pre-populates
- [ ] Labels page shows 5 new labels
- [ ] Milestones page shows v1.3.0

## Manual step: GitHub Project
The token needs the `project` scope to create a GitHub Project via API. Once added, run:
```bash
gh api graphql -f query='
mutation {
  createProjectV2(input: {ownerId: "MDQ6VXNlcjc1MzkyODgz", title: "Stats for Strava Config Tool"}) {
    projectV2 { id number url }
  }
}'
```
Then link the repo and add the Type field as described in the plan.

## Checklist
- [x] CHANGELOG.md — no user-facing change, skipping
- [x] No version bump needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)