### PR TITLE
feat(metrics): add peak power output exclusions UI — v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.7] — 2026-04-18
+
+### Added
+
+- **Peak power output exclusions** — new UI section on the Metrics configuration page to manage the `excludeActivitiesFromPeakPowerOutputs` array. Users can add or remove Strava activity IDs (found at the end of the activity URL) to blacklist specific activities from peak power calculations. Duplicate entries are silently ignored.
+
+### Changed
+
+- Updated `metricsSchema` in `configSchemas.js` to include `excludeActivitiesFromPeakPowerOutputs` as an optional array of strings with a default of `[]`.
+- Updated `public/config-merged.yaml` to include `excludeActivitiesFromPeakPowerOutputs: []` with developer comments in the metrics section.
+
+### Documentation
+
+- Updated `docs/DEVELOPER.md` to document the new Peak Power Output Exclusions section under Metrics Components.
+- Fixed LOG_FILE env var names and corrected stale docker-compose examples in SFS Console docs (`docs/SFS-CONSOLE-SETUP.md`, `docs/TROUBLESHOOTING.md`, `public/docs/help/sfs-console.md`).
+
+---
+
 ## [1.2.6] — 2026-03-10
 
 ### Added

--- a/app/(config)/_components/MetricsConfigEditor.jsx
+++ b/app/(config)/_components/MetricsConfigEditor.jsx
@@ -24,15 +24,16 @@ import { useSportsList } from '../../../src/contexts/SportsListContext';
  * MetricsConfigEditor - Handles metrics configuration fields
  * Focuses on Eddington score configuration with array of sport groupings
  */
-const MetricsConfigEditor = ({ 
-  initialData, 
-  onSave, 
-  onCancel, 
+const MetricsConfigEditor = ({
+  initialData,
+  onSave,
+  onCancel,
   isLoading,
-  onDirtyChange 
+  onDirtyChange
 }) => {
   const { sportsList } = useSportsList();
   const [expandedEddington, setExpandedEddington] = useState({});
+  const [activityIdInput, setActivityIdInput] = useState('');
 
   // Custom validation for metrics fields
   const validateMetricsFields = useCallback((formData, getNestedValue) => {
@@ -159,6 +160,26 @@ const MetricsConfigEditor = ({
           handleFieldChange('eddington', updated);
         }, [eddingtonArray, handleFieldChange]);
 
+        const excludedActivities = getNestedValue(formData, 'excludeActivitiesFromPeakPowerOutputs') || [];
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const handleAddExcludedActivity = useCallback(() => {
+          const trimmed = activityIdInput.trim();
+          if (!trimmed) return;
+          if (!excludedActivities.includes(trimmed)) {
+            handleFieldChange('excludeActivitiesFromPeakPowerOutputs', [...excludedActivities, trimmed]);
+          }
+          setActivityIdInput('');
+        }, [activityIdInput, excludedActivities, handleFieldChange]);
+
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const handleRemoveExcludedActivity = useCallback((id) => {
+          handleFieldChange(
+            'excludeActivitiesFromPeakPowerOutputs',
+            excludedActivities.filter(v => v !== id)
+          );
+        }, [excludedActivities, handleFieldChange]);
+
         // Memoize count computations to avoid re-filtering on every render
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const navBarCount = useMemo(() =>
@@ -174,8 +195,94 @@ const MetricsConfigEditor = ({
 
         return (
           <VStack align="stretch" gap={6}>
+            {/* Peak Power Output Exclusions */}
+            <Box p={4} bg="cardBg" borderRadius="md" border="1px solid" borderColor="border" boxShadow="sm">
+              <VStack align="stretch" gap={4}>
+                <Box>
+                  <Text fontSize={{ base: "md", sm: "lg" }} fontWeight="semibold" color="text">
+                    Exclude Activities from Peak Power Outputs
+                  </Text>
+                  <Text fontSize={{ base: "xs", sm: "sm" }} color="textMuted">
+                    Activity IDs added here will be excluded from peak power output calculations.
+                  </Text>
+                </Box>
+
+                <Field.Root>
+                  <Field.Label>Excluded Activity IDs</Field.Label>
+
+                  {excludedActivities.length > 0 && (
+                    <VStack align="stretch" gap={2} mb={3}>
+                      {excludedActivities.map((id) => (
+                        <Flex
+                          key={id}
+                          p={2}
+                          px={3}
+                          bg="panelBg"
+                          border="1px solid"
+                          borderColor="border"
+                          borderRadius="md"
+                          align="center"
+                          justify="space-between"
+                          gap={2}
+                          _hover={{ borderColor: "primary" }}
+                        >
+                          <Text fontSize="sm" color="text" flex="1">{id}</Text>
+                          <IconButton
+                            size="sm"
+                            variant="ghost"
+                            colorPalette="red"
+                            onClick={() => handleRemoveExcludedActivity(id)}
+                            aria-label="Remove activity ID"
+                          >
+                            <MdDelete />
+                          </IconButton>
+                        </Flex>
+                      ))}
+                    </VStack>
+                  )}
+
+                  <HStack gap={2}>
+                    <Input
+                      value={activityIdInput}
+                      onChange={(e) => setActivityIdInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleAddExcludedActivity();
+                        }
+                      }}
+                      placeholder="e.g., 18161039085"
+                      bg="inputBg"
+                      flex="1"
+                    />
+                    <Button
+                      onClick={handleAddExcludedActivity}
+                      colorPalette="blue"
+                      size="md"
+                      px={4}
+                      disabled={!activityIdInput.trim()}
+                    >
+                      <MdAdd />
+                      Add
+                    </Button>
+                  </HStack>
+
+                  <Field.HelperText>
+                    Activity IDs are typically numeric values found at the end of the Strava activity URL
+                    (e.g., strava.com/activities/18161039085).
+                  </Field.HelperText>
+
+                  {excludedActivities.length === 0 && (
+                    <Text fontSize="sm" color="textMuted" mt={2} fontStyle="italic">
+                      No activities excluded. All activities are included in peak power calculations.
+                    </Text>
+                  )}
+                </Field.Root>
+              </VStack>
+            </Box>
+
             {/* Introduction */}
-            <Box 
+            <Box
               p={4} 
               bg="blue.50"
               _dark={{ 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -788,6 +788,20 @@ AIConfigurationField.propTypes = {
 
 ### Metrics Components
 
+#### Peak Power Output Exclusions
+
+Section for excluding specific Strava activities from peak power output calculations.
+
+**Location**: `app/(config)/_components/MetricsConfigEditor.jsx`
+
+**Field**: `excludeActivitiesFromPeakPowerOutputs` (array of strings)
+
+**Features**:
+- Add/remove Strava activity IDs to exclude from peak power calculations
+- Activity IDs are strings (typically numeric, from the Strava activity URL)
+- Duplicate entries are silently ignored
+- Positioned above the Eddington section on the Metrics config page
+
 #### EddingtonConfigurationField
 
 Field for managing Eddington score configurations.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -24,7 +24,7 @@ The core feature of this tool is a visual form-based editor that replaces manual
 | **Athlete** | Birthday, heart rate zones, weight history, FTP data, resting heart rate |
 | **Appearance** | Locale, units, date/time formats, dashboard layout |
 | **Import** | Activity import settings, sport type filters, webhooks |
-| **Metrics** | Eddington score calculation, metric groupings |
+| **Metrics** | Eddington score calculation, metric groupings, peak power output exclusions |
 | **Gear** | Equipment tracking, purchase prices, maintenance, currency |
 | **Zwift** | Zwift level and racing score integration |
 | **Integrations** | Notification services, AI provider configuration |

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/public/config-merged.yaml
+++ b/public/config-merged.yaml
@@ -297,6 +297,14 @@ import:
 metrics:
 
 #---------------------------------#
+# Peak Power Output Exclusion Settings
+#---------------------------------#
+  # An array of activity ids to exclude from peak power outputs.
+  # This allows you to blacklist specific activity IDs from the peak power calculation.
+  # ["123456789", "987654321"]
+  excludeActivitiesFromPeakPowerOutputs: []
+
+#---------------------------------#
 # Eddington Score Configuration Settings
 #---------------------------------#
   eddington:

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/src/schemas/configSchemas.js
+++ b/src/schemas/configSchemas.js
@@ -560,6 +560,13 @@ export const metricsSchema = {
   title: "Metrics Configuration",
   description: "Performance metrics and scoring settings",
   properties: {
+    excludeActivitiesFromPeakPowerOutputs: {
+      type: "array",
+      title: "Exclude Activities from Peak Power Outputs",
+      description: "An array of activity IDs to exclude from peak power calculations. Activity IDs are the numeric value at the end of the Strava activity URL (e.g., strava.com/activities/18161039085).",
+      items: { type: "string" },
+      default: []
+    },
     eddington: {
       type: "array",
       title: "Eddington Score Configuration",


### PR DESCRIPTION
## Summary
- Add UI section to Metrics page for managing `excludeActivitiesFromPeakPowerOutputs`
- Bump version to 1.2.7

## Changes included
- **New UI**: Card on Metrics config page with add/remove input for Strava activity IDs to exclude from peak power calculations. Duplicate entries silently ignored.
- **Schema**: Added `excludeActivitiesFromPeakPowerOutputs` to `metricsSchema` (optional array of strings, default `[]`)
- **Config**: Updated `public/config-merged.yaml` with field and developer comments
- **Docs**: Updated `docs/DEVELOPER.md`, `docs/FEATURES.md`, and `CHANGELOG.md`
- **Also includes**: SFS Console LOG_FILE env var doc fixes (commit bb0dd0b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)