### PR TITLE
feat(widgets): Training Goals visual editor + pre-fill pulldown v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.8] — 2026-04-28
+
+### Added
+
+- **Training Goals visual editor** — clicking the pencil icon on any `trainingGoals` widget in Settings → Widgets now opens a purpose-built four-tab modal (Weekly / Monthly / Yearly / Lifetime). Each goal entry supports: label, enabled toggle, goal type (distance / elevation / movingTime / numberOfActivities / calories), unit (km / m / mi / ft / hour / minute), goal value, sport type multi-select, and optional date range restriction. Multiple `trainingGoals` widget instances are supported.
+- **Add Widget pre-fill pulldown** — the Add Widget form now includes a dropdown listing all `allowMultiple: true` widget definitions. Selecting one pre-fills all technical fields (config template, default config, flags) so the user only needs to supply a unique Display Name and Description.
+- **"Sync to defaults" button in Dashboard Layout Editor** — when a widget's stored config in `config.yaml` has drifted from the current widget definition's `defaultConfig` (e.g. after updating training goals), an orange "Sync to defaults" button appears next to the Configuration toggle. Clicking it replaces the widget's config with a deep copy of the current definition defaults and marks the layout as dirty.
+- **Nested object display in Dashboard Layout Editor** — widget config values that are nested objects (e.g. the `goals` structure of Training Goals) now render as a formatted, scrollable JSON preview instead of `[object Object]`.
+
+### Fixed
+
+- **Widget deletion by index** — `handleDeleteWidget` now filters by array index instead of widget name, so deleting one of multiple `allowMultiple` widgets with the same name no longer removes all instances.
+- **Expand/collapse keyed by index** — expand/collapse state in the Widget Definitions editor now uses array index as the key, so multiple widgets sharing the same `name` toggle independently.
+- **Duplicate name validation for `allowMultiple` widgets** — the validator now permits adding a second widget with the same `name` when `allowMultiple: true`; it enforces Display Name uniqueness per name instead.
+- **YAML serialization of object arrays** — `widgetDefinitionsManager.js` `toYAML()` was calling `.toString()` on object items in arrays, producing `- [object Object]`. Fixed to serialize each property as a proper YAML block sequence entry.
+- **`config.yaml` complex config formatting** — `update-section` route was using `JSON.stringify` for nested config objects, collapsing training goals onto a single line. Replaced with a recursive formatter that expands objects and arrays into readable YAML flow style.
+- **Dev server OOM crash on navigation** — `TrainingGoalsConfigModal` is now loaded via `next/dynamic({ ssr: false })` and `DateInput` (`react-datepicker` + `date-fns`, 32 MB) is replaced with a native `<input type="date">` in `TrainingGoalEntryEditor`, preventing heap exhaustion when Turbopack compiled the training goals chunk.
+
+---
+
 ## [1.2.7] — 2026-04-18
 
 ### Added

--- a/app/api/update-section/route.js
+++ b/app/api/update-section/route.js
@@ -369,6 +369,66 @@ export async function POST(request) {
       }
     }
     
+    // Recursively format a widget config value as readable YAML flow style.
+    // Objects expand to multiple lines; goal entry arrays put one item per line;
+    // primitive arrays stay inline: ['Ride', 'VirtualRide'].
+    function formatWidgetConfigValue(value, baseSpaces) {
+      if (value === null || value === undefined) return 'null';
+      if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+      if (typeof value === 'string') return `'${value}'`;
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) return '[]';
+        if (typeof value[0] === 'object' && value[0] !== null) {
+          // Array of objects (e.g. goal entries) — one item per line, inline flow
+          const innerSpaces = baseSpaces + '  ';
+          const lines = ['['];
+          value.forEach(item => {
+            const fields = Object.entries(item).map(([k, v]) => {
+              if (v === null || v === undefined) return `${k}: null`;
+              if (Array.isArray(v)) {
+                if (v.length === 0) return `${k}: []`;
+                return `${k}: [${v.map(i => typeof i === 'string' ? `'${i}'` : String(i)).join(', ')}]`;
+              }
+              if (typeof v === 'object') {
+                const nested = Object.entries(v).map(([nk, nv]) => `${nk}: '${nv}'`).join(', ');
+                return `${k}: { ${nested} }`;
+              }
+              if (typeof v === 'string') return `${k}: '${v}'`;
+              return `${k}: ${v}`;
+            }).join(', ');
+            lines.push(`${innerSpaces}{ ${fields} },`);
+          });
+          lines.push(`${baseSpaces}]`);
+          return lines.join('\n');
+        }
+        // Primitive array — inline single quotes
+        return `[${value.map(v => typeof v === 'string' ? `'${v}'` : String(v)).join(', ')}]`;
+      }
+
+      if (typeof value === 'object') {
+        const entries = Object.entries(value);
+        if (entries.length === 0) return '{}';
+        const innerSpaces = baseSpaces + '  ';
+        const lines = ['{'];
+        entries.forEach(([k, v]) => {
+          const fv = formatWidgetConfigValue(v, innerSpaces);
+          if (fv.includes('\n')) {
+            const vLines = fv.split('\n');
+            lines.push(`${innerSpaces}'${k}': ${vLines[0]}`);
+            for (let j = 1; j < vLines.length - 1; j++) lines.push(vLines[j]);
+            lines.push(vLines[vLines.length - 1] + ',');
+          } else {
+            lines.push(`${innerSpaces}'${k}': ${fv},`);
+          }
+        });
+        lines.push(`${baseSpaces}}`);
+        return lines.join('\n');
+      }
+
+      return String(value);
+    }
+
     // Helper function to add a YAML field with proper formatting
     function addYamlField(result, baseIndent, key, value) {
       // Special handling for dashboard.layout - use JSON-like formatting or null
@@ -413,31 +473,14 @@ export async function POST(request) {
             
             // Handle config if present
             if (widget.config && Object.keys(widget.config).length > 0) {
+              const configBodySpaces = objIndent + '  ';
+              const configFormatted = formatWidgetConfigValue(widget.config, configBodySpaces);
               result.push(`${objIndent}"config":`);
-              result.push(`${objIndent}  {`);
-              
-              const configKeys = Object.keys(widget.config);
-              configKeys.forEach((configKey, idx) => {
-                const configValue = widget.config[configKey];
-                const isLast = idx === configKeys.length - 1;
-                const comma = isLast ? ',' : ',';
-                
-                if (Array.isArray(configValue)) {
-                  // Format arrays inline
-                  const arrayStr = JSON.stringify(configValue);
-                  result.push(`${objIndent}    "${configKey}": ${arrayStr}${comma}`);
-                } else if (typeof configValue === 'object' && configValue !== null) {
-                  // Format nested objects
-                  result.push(`${objIndent}    "${configKey}": ${JSON.stringify(configValue)}${comma}`);
-                } else if (typeof configValue === 'string') {
-                  result.push(`${objIndent}    "${configKey}": "${configValue}"${comma}`);
-                } else {
-                  // Numbers, booleans, null
-                  result.push(`${objIndent}    "${configKey}": ${configValue}${comma}`);
-                }
+              const configLines = configFormatted.split('\n');
+              configLines.forEach((line, i) => {
+                result.push(i === 0 ? `${configBodySpaces}${line}` : line);
               });
-              
-              result.push(`${objIndent}  },`);
+              result[result.length - 1] += ',';
             }
             
             // Closing brace

--- a/app/utilities/_components/DashboardEditor.jsx
+++ b/app/utilities/_components/DashboardEditor.jsx
@@ -165,6 +165,17 @@ function DashboardEditor({ dashboardLayout, onClose, onSave }) {
     }));
   }, []);
 
+  const handleResetConfigToDefaults = useCallback((index) => {
+    setLayout(prevLayout => {
+      const def = widgetDefinitions[prevLayout[index].widget];
+      if (!def?.defaultConfig) return prevLayout;
+      const newLayout = [...prevLayout];
+      newLayout[index] = { ...newLayout[index], config: JSON.parse(JSON.stringify(def.defaultConfig)) };
+      return newLayout;
+    });
+    setIsDirty(true);
+  }, [widgetDefinitions]);
+
   const handleConfigChange = useCallback((index, configKey, value) => {
     setLayout(prevLayout => {
       const newLayout = [...prevLayout];
@@ -313,6 +324,7 @@ function DashboardEditor({ dashboardLayout, onClose, onSave }) {
                     onWidthChange={handleWidthChange}
                     onEnabledToggle={handleEnabledToggle}
                     onConfigChange={handleConfigChange}
+                    onResetToDefaults={handleResetConfigToDefaults}
                     onToggleConfigEditor={toggleConfigEditor}
                     onDragStart={handleDragStart}
                     onDragOver={handleDragOver}

--- a/app/utilities/_components/dashboard/DashboardWidgetItem.jsx
+++ b/app/utilities/_components/dashboard/DashboardWidgetItem.jsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Flex, Text, Button, Input, VStack, NativeSelectRoot, NativeSelectField } from '@chakra-ui/react';
-import { MdDragIndicator, MdExpandMore, MdChevronRight, MdArrowUpward, MdArrowDownward, MdDelete, MdClose } from 'react-icons/md';
+import { MdDragIndicator, MdExpandMore, MdChevronRight, MdArrowUpward, MdArrowDownward, MdDelete, MdClose, MdSync } from 'react-icons/md';
 
 /**
  * DashboardWidgetItem - Displays a single widget in the dashboard layout editor
@@ -23,6 +23,7 @@ const DashboardWidgetItem = ({
   onWidthChange,
   onEnabledToggle,
   onConfigChange,
+  onResetToDefaults,
   onToggleConfigEditor,
   onDragStart,
   onDragOver,
@@ -34,6 +35,10 @@ const DashboardWidgetItem = ({
   const widgetDef = widgetDefinitions[widget.widget];
   const displayName = widgetDef?.displayName || widget.widget;
   const description = widgetDef?.description || '';
+
+  const configDiffersFromDefault = widgetDef?.defaultConfig != null &&
+    widget.config != null &&
+    JSON.stringify(widget.config) !== JSON.stringify(widgetDef.defaultConfig);
 
   return (
     <Box
@@ -189,15 +194,27 @@ const DashboardWidgetItem = ({
           {/* Widget Configuration */}
           {widgetDef?.hasConfig && widget.config !== undefined && (
             <Box mt={3} pt={3} borderTopWidth="1px" borderColor="border">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onToggleConfigEditor(index)}
-                mb={expandedConfigs[index] ? 2 : 0}
-                leftIcon={expandedConfigs[index] ? <MdExpandMore /> : <MdChevronRight />}
-              >
-                Configuration
-              </Button>
+              <Flex align="center" justify="space-between" mb={expandedConfigs[index] ? 2 : 0}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onToggleConfigEditor(index)}
+                  leftIcon={expandedConfigs[index] ? <MdExpandMore /> : <MdChevronRight />}
+                >
+                  Configuration
+                </Button>
+                {configDiffersFromDefault && (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    colorPalette="orange"
+                    onClick={() => onResetToDefaults(index)}
+                    title="This widget's config differs from the current widget definition defaults. Click to sync."
+                  >
+                    <MdSync /> Sync to defaults
+                  </Button>
+                )}
+              </Flex>
 
               {expandedConfigs[index] && (
                 <VStack align="stretch" gap={3} pl={4}>
@@ -307,6 +324,24 @@ const DashboardWidgetItem = ({
                               ))}
                             </Flex>
                           </VStack>
+                        ) : typeof value === 'object' && value !== null ? (
+                          <Box
+                            as="pre"
+                            bg="inputBg"
+                            p={2}
+                            borderRadius="md"
+                            border="1px solid"
+                            borderColor="border"
+                            fontSize="xs"
+                            fontFamily="monospace"
+                            whiteSpace="pre-wrap"
+                            color="text"
+                            maxH="200px"
+                            overflowY="auto"
+                            flex="1"
+                          >
+                            {JSON.stringify(value, null, 2)}
+                          </Box>
                         ) : (
                           <Input
                             type="text"
@@ -353,6 +388,7 @@ DashboardWidgetItem.propTypes = {
   onWidthChange: PropTypes.func.isRequired,
   onEnabledToggle: PropTypes.func.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  onResetToDefaults: PropTypes.func.isRequired,
   onToggleConfigEditor: PropTypes.func.isRequired,
   onDragStart: PropTypes.func.isRequired,
   onDragOver: PropTypes.func.isRequired,

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -454,6 +454,67 @@ function MyComponent() {
   - `message` (string): Text to display
   - `type` (string): 'success' | 'error' | 'warning' | 'info'
 
+## Widget Definitions System
+
+### Overview
+
+Widget definitions are stored in `{defaultPath}/settings/widget-definitions.yaml` and loaded at runtime by `src/utils/widgetDefinitionsManager.js`. Each definition has the shape:
+
+```javascript
+{
+  name: string,           // camelCase identifier
+  displayName: string,
+  description: string,
+  allowMultiple: boolean, // whether multiple instances can exist in the dashboard
+  hasConfig: boolean,
+  configTemplate: string, // optional YAML schema (shown in Dashboard Layout Editor)
+  defaultConfig: object   // optional initial values when widget is added to layout
+}
+```
+
+### Training Goals Widget
+
+The `trainingGoals` widget has a complex `defaultConfig`:
+
+```javascript
+{
+  goals: {
+    weekly: [],    // array of goal entry objects
+    monthly: [],
+    yearly: [],
+    lifetime: []
+  }
+}
+```
+
+Each goal entry: `{ label, enabled, type, unit?, goal, sportTypesToInclude, restrictToDateRange? }`
+
+Valid `type` values: `distance`, `elevation`, `movingTime`, `numberOfActivities`, `calories`  
+Valid `unit` values: `km`, `m`, `mi`, `ft`, `hour`, `minute` (not applicable for `numberOfActivities`/`calories`)
+
+### Training Goals Editor Components
+
+| File | Role |
+|------|------|
+| `src/utils/trainingGoalsValidation.js` | Constants (GOAL_TYPES, UNIT_TYPES, PERIODS) and `validateGoalEntry` / `validateTrainingGoalsConfig` |
+| `src/components/widgets/training-goals/TrainingGoalEntryEditor.jsx` | Expandable card for a single goal entry |
+| `src/components/widgets/training-goals/GoalPeriodList.jsx` | Manages the list of goals for one period (add/remove/reorder) |
+| `src/components/widgets/TrainingGoalsConfigModal.jsx` | Four-tab modal; loaded via `next/dynamic({ ssr: false })` to avoid pulling `react-datepicker`/`date-fns` into the main bundle |
+
+### YAML Serialization
+
+`widgetDefinitionsManager.js` uses a hand-written `toYAML()` / `fromYAML()` pair rather than the `yaml` library for serialization (to preserve comment structure). The `serializeValue()` helper handles nested arrays of objects: the first property of each item uses `- key: val` and subsequent properties use 4-space continuation indent aligned with the text after the dash. The `fromYAML()` parser delegates `defaultConfig` blocks to `YAML.parse()` (the library) after stripping 4 leading spaces.
+
+### config.yaml Layout Serialization
+
+`app/api/update-section/route.js` serializes `dashboard.layout` with `addYamlField()`. The `formatWidgetConfigValue()` helper (defined just above `addYamlField`) handles nested objects recursively: objects expand to multi-line flow style with single-quoted keys; arrays of objects render one item per line as inline flow mappings; primitive arrays stay inline.
+
+### Bundle Size Caution
+
+`react-datepicker` pulls in `date-fns` (~32 MB). Any component that imports `DateInput` directly will add this to the compiled chunk. In the training goals editor, date range inputs use a native `<Input type="date">` instead to avoid this. If you need the full date picker in a new feature, wrap the component with `next/dynamic({ ssr: false })`.
+
+---
+
 ## Reusable Components
 
 ### Form Field Components

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -62,9 +62,11 @@ Manage sport types and activity classifications:
 
 Access via **Settings > Widgets** to manage widget templates:
 
-- **View widgets** - Widgets are grouped by instance rules
+- **View widgets** - Widgets are grouped by instance rules (single-use vs. multi-use)
 - **Expand details** - Click the toggle arrow to see properties and configuration templates
 - **Add/Edit/Delete** - Use the respective buttons to manage widget definitions
+- **Pre-fill from existing** - When adding a widget, select an existing multi-use widget from the dropdown to pre-fill all technical fields; only a unique Display Name is required
+- **Training Goals visual editor** - Clicking the pencil icon on a `trainingGoals` widget opens a four-tab (Weekly / Monthly / Yearly / Lifetime) goal editor with support for goal type, unit, sport type filtering, and optional date range restrictions
 - **Save changes** - Click the Save button to write all changes to file
 
 Features include:
@@ -72,6 +74,7 @@ Features include:
 - 20+ built-in widget definitions
 - Support for single-instance and multi-instance widgets
 - Custom configuration templates for each widget
+- Visual editor for complex widget configs (Training Goals)
 - Define widget metadata and instance rules
 
 ---

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/src/components/WidgetDefinitionsEditor.jsx
+++ b/src/components/WidgetDefinitionsEditor.jsx
@@ -7,6 +7,12 @@ import { ConfirmDialog } from '../../app/_components/ui/ConfirmDialog';
 import WidgetListItem from './widgets/WidgetListItem';
 import WidgetFormModal from './widgets/WidgetFormModal';
 import { validateWidgetForm } from '../utils/widgetValidation';
+import dynamic from 'next/dynamic';
+
+const TrainingGoalsConfigModal = dynamic(
+  () => import('./widgets/TrainingGoalsConfigModal'),
+  { ssr: false }
+);
 
 export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
   const [widgetDefinitions, setWidgetDefinitions] = useState([]);
@@ -21,6 +27,8 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
   const [showAddWidgetModal, setShowAddWidgetModal] = useState(false);
   const [showEditWidgetModal, setShowEditWidgetModal] = useState(false);
   const [editingWidget, setEditingWidget] = useState(null);
+  const [showTrainingGoalsModal, setShowTrainingGoalsModal] = useState(false);
+  const [trainingGoalsWidget, setTrainingGoalsWidget] = useState(null);
   const [modalError, setModalError] = useState('');
   const [formData, setFormData] = useState({
     name: '',
@@ -64,15 +72,15 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
     setTimeout(() => setMessage(''), 3000);
   };
 
-  const toggleWidget = (name) => {
-    setExpandedWidgets(prev => ({ ...prev, [name]: !prev[name] }));
+  const toggleWidget = (idx) => {
+    setExpandedWidgets(prev => ({ ...prev, [idx]: !prev[idx] }));
   };
 
   const collapseAll = () => setExpandedWidgets({});
 
   const expandAll = () => {
     const expanded = {};
-    widgetDefinitions.forEach(w => expanded[w.name] = true);
+    widgetDefinitions.forEach((_, i) => { expanded[i] = true; });
     setExpandedWidgets(expanded);
   };
 
@@ -169,14 +177,23 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
     showMessage('Widget definition updated successfully');
   };
 
-  const handleDeleteWidget = (name) => {
+  const handleDeleteWidget = (idx) => {
+    const widget = widgetDefinitions[idx];
     setConfirmDialog({
       isOpen: true,
       title: 'Delete Widget Definition',
-      message: `Are you sure you want to delete the widget definition "${name}"? This action cannot be undone.`,
+      message: `Are you sure you want to delete the widget definition "${widget.displayName}"? This action cannot be undone.`,
       onConfirm: () => {
-        const updatedDefinitions = widgetDefinitions.filter(w => w.name !== name);
-        setWidgetDefinitions(updatedDefinitions);
+        setWidgetDefinitions(prev => prev.filter((_, i) => i !== idx));
+        setExpandedWidgets(prev => {
+          const next = {};
+          Object.keys(prev).forEach(key => {
+            const k = parseInt(key);
+            if (k < idx) next[k] = prev[key];
+            else if (k > idx) next[k - 1] = prev[key];
+          });
+          return next;
+        });
         showMessage('Widget definition deleted successfully');
         setConfirmDialog({ isOpen: false, onConfirm: null, title: '', message: '' });
       }
@@ -217,6 +234,11 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
   };
 
   const openEditModal = (widget) => {
+    if (widget.name === 'trainingGoals') {
+      setTrainingGoalsWidget(widget);
+      setShowTrainingGoalsModal(true);
+      return;
+    }
     setEditingWidget(widget);
     setFormData({
       name: widget.name,
@@ -230,13 +252,20 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
     setShowEditWidgetModal(true);
   };
 
+  const handleSaveTrainingGoals = (updatedWidget) => {
+    setWidgetDefinitions(prev => prev.map(w => w === trainingGoalsWidget ? updatedWidget : w));
+    setShowTrainingGoalsModal(false);
+    setTrainingGoalsWidget(null);
+    showMessage('Training Goals widget updated successfully');
+  };
+
   // Group widgets by allowMultiple property
   const allowMultipleWidgets = widgetDefinitions.filter(w => w.allowMultiple);
   const allowOnceWidgets = widgetDefinitions.filter(w => !w.allowMultiple);
 
-  // Get the settings location
-  const defaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
-  const settingsLocation = `${defaultPath}settings`;
+  // Get the settings location (normalize separators to match what the file I/O uses)
+  const rawDefaultPath = getSetting('files.defaultPath', '~/Documents/strava-config-tool/');
+  const settingsLocation = rawDefaultPath.replace(/[\\/]+$/, '').replace(/\\/g, '/') + '/settings';
 
   return (
     <Box p={6} bg="pageBg" minH="100vh">
@@ -335,16 +364,19 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
               Widgets that can be added multiple times ({allowMultipleWidgets.length})
             </Heading>
             <VStack gap={2} align="stretch">
-              {allowMultipleWidgets.map(widget => (
-                <WidgetListItem
-                  key={widget.name}
-                  widget={widget}
-                  isExpanded={expandedWidgets[widget.name]}
-                  onToggle={toggleWidget}
-                  onEdit={openEditModal}
-                  onDelete={handleDeleteWidget}
-                />
-              ))}
+              {allowMultipleWidgets.map(widget => {
+                const idx = widgetDefinitions.indexOf(widget);
+                return (
+                  <WidgetListItem
+                    key={idx}
+                    widget={widget}
+                    isExpanded={expandedWidgets[idx] || false}
+                    onToggle={() => toggleWidget(idx)}
+                    onEdit={() => openEditModal(widget)}
+                    onDelete={() => handleDeleteWidget(idx)}
+                  />
+                );
+              })}
             </VStack>
           </Box>
 
@@ -353,16 +385,19 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
               Widgets that can be added once ({allowOnceWidgets.length})
             </Heading>
             <VStack gap={2} align="stretch">
-              {allowOnceWidgets.map(widget => (
-                <WidgetListItem
-                  key={widget.name}
-                  widget={widget}
-                  isExpanded={expandedWidgets[widget.name]}
-                  onToggle={toggleWidget}
-                  onEdit={openEditModal}
-                  onDelete={handleDeleteWidget}
-                />
-              ))}
+              {allowOnceWidgets.map(widget => {
+                const idx = widgetDefinitions.indexOf(widget);
+                return (
+                  <WidgetListItem
+                    key={idx}
+                    widget={widget}
+                    isExpanded={expandedWidgets[idx] || false}
+                    onToggle={() => toggleWidget(idx)}
+                    onEdit={() => openEditModal(widget)}
+                    onDelete={() => handleDeleteWidget(idx)}
+                  />
+                );
+              })}
             </VStack>
           </Box>
         </VStack>
@@ -377,6 +412,7 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
         onSubmit={handleAddWidget}
         onClose={() => { setShowAddWidgetModal(false); resetForm(); }}
         error={modalError}
+        widgetDefinitions={widgetDefinitions}
       />
 
       {/* Edit Widget Modal */}
@@ -389,6 +425,19 @@ export default function WidgetDefinitionsEditor({ settings, onDirtyChange }) {
         onClose={() => { setShowEditWidgetModal(false); setEditingWidget(null); resetForm(); }}
         error={modalError}
       />
+
+      {/* Training Goals Config Modal */}
+      {showTrainingGoalsModal && (
+        <TrainingGoalsConfigModal
+          isOpen={showTrainingGoalsModal}
+          widget={trainingGoalsWidget}
+          onSave={handleSaveTrainingGoals}
+          onClose={() => {
+            setShowTrainingGoalsModal(false);
+            setTrainingGoalsWidget(null);
+          }}
+        />
+      )}
 
       {/* Confirmation Dialog */}
       <ConfirmDialog

--- a/src/components/widgets/TrainingGoalsConfigModal.jsx
+++ b/src/components/widgets/TrainingGoalsConfigModal.jsx
@@ -1,0 +1,239 @@
+import React, { useState } from 'react';
+import {
+  Box, Flex, Heading, VStack, Button, Field, Input, Textarea, Text, Tabs, Badge, Icon
+} from '@chakra-ui/react';
+import { MdClose } from 'react-icons/md';
+import { useSportsList } from '../../contexts/SportsListContext';
+import GoalPeriodList from './training-goals/GoalPeriodList';
+import { validateTrainingGoalsConfig, PERIODS } from '../../utils/trainingGoalsValidation';
+
+const PERIOD_LABELS = {
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+  yearly: 'Yearly',
+  lifetime: 'Lifetime',
+};
+
+const TrainingGoalsConfigModal = ({ isOpen, widget, onSave, onClose }) => {
+  const { sportsList } = useSportsList();
+
+  const [displayName, setDisplayName] = useState(widget?.displayName || '');
+  const [description, setDescription] = useState(widget?.description || '');
+  const [goalsConfig, setGoalsConfig] = useState(() => {
+    const base = { goals: { weekly: [], monthly: [], yearly: [], lifetime: [] } };
+    if (!widget?.defaultConfig) return base;
+    return JSON.parse(JSON.stringify(widget.defaultConfig));
+  });
+  const [errors, setErrors] = useState({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  if (!isOpen) return null;
+
+  const getGoals = period => goalsConfig?.goals?.[period] || [];
+
+  const handlePeriodChange = (period, newArray) => {
+    const updated = {
+      ...goalsConfig,
+      goals: { ...goalsConfig.goals, [period]: newArray }
+    };
+    setGoalsConfig(updated);
+    if (submitAttempted) {
+      setErrors(validateTrainingGoalsConfig(updated));
+    }
+  };
+
+  const handleSave = () => {
+    setSubmitAttempted(true);
+
+    const newErrors = {};
+    if (!displayName.trim()) {
+      newErrors._displayName = 'Display name is required';
+    }
+
+    const configErrors = validateTrainingGoalsConfig(goalsConfig);
+    Object.assign(newErrors, configErrors);
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    onSave({
+      ...widget,
+      displayName: displayName.trim(),
+      description: description.trim(),
+      defaultConfig: goalsConfig,
+    });
+  };
+
+  const hasConfigErrors = submitAttempted && Object.keys(errors).filter(k => k !== '_displayName').length > 0;
+
+  return (
+    <Flex
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      bg="rgba(0, 0, 0, 0.7)"
+      align="center"
+      justify="center"
+      zIndex={1000}
+      onClick={onClose}
+    >
+      <Flex
+        direction="column"
+        bg="cardBg"
+        border="2px solid"
+        borderColor="border"
+        borderRadius="lg"
+        boxShadow="xl"
+        w="95%"
+        maxW="800px"
+        maxH="92vh"
+        overflow="hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <Flex
+          justify="space-between"
+          align="center"
+          px={6}
+          py={4}
+          bg="panelBg"
+          borderBottom="1px solid"
+          borderColor="border"
+        >
+          <Heading as="h4" size="lg" color="text">Edit Training Goals Widget</Heading>
+          <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close">
+            <Icon><MdClose /></Icon>
+          </Button>
+        </Flex>
+
+        {/* Body */}
+        <Box px={6} py={4} overflowY="auto" flex={1}>
+          <VStack align="stretch" gap={5}>
+            {/* Display name + description */}
+            <Field.Root invalid={!!errors._displayName}>
+              <Field.Label color="text">Display Name*</Field.Label>
+              <Input
+                placeholder="e.g. Cycling Goals 2026"
+                value={displayName}
+                onChange={e => {
+                  setDisplayName(e.target.value);
+                  if (submitAttempted && e.target.value.trim()) {
+                    setErrors(prev => { const n = { ...prev }; delete n._displayName; return n; });
+                  }
+                }}
+                bg="inputBg"
+              />
+              <Field.HelperText fontSize="xs" color="textMuted">
+                Must be unique — used to distinguish multiple Training Goals widgets
+              </Field.HelperText>
+              {errors._displayName && <Field.ErrorText>{errors._displayName}</Field.ErrorText>}
+            </Field.Root>
+
+            <Field.Root>
+              <Field.Label color="text">Description</Field.Label>
+              <Textarea
+                placeholder="Describe what this training goals widget tracks..."
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                rows={2}
+                bg="inputBg"
+              />
+            </Field.Root>
+
+            {/* Info banner */}
+            <Box p={3} bg="infoBg" borderRadius="md" border="1px solid" borderColor="infoBorder">
+              <Text fontSize="xs" color="infoText">
+                Configure goals for each time period. Each goal defines a target (distance, elevation, etc.)
+                that Stats for Strava will track on your dashboard.
+              </Text>
+            </Box>
+
+            {/* Tabs for periods */}
+            <Tabs.Root defaultValue="weekly">
+              <Tabs.List
+                borderBottom="1px solid"
+                borderColor="border"
+                bg="panelBg"
+              >
+                {PERIODS.map(period => {
+                  const count = getGoals(period).length;
+                  const periodErrors = Object.keys(errors).filter(k => k.startsWith(`${period}[`)).length;
+                  return (
+                    <Tabs.Trigger key={period} value={period}>
+                      <Flex align="center" gap={1}>
+                        {PERIOD_LABELS[period]}
+                        <Badge
+                          colorPalette={periodErrors > 0 ? 'red' : 'gray'}
+                          variant="subtle"
+                          size="sm"
+                        >
+                          {count}
+                        </Badge>
+                      </Flex>
+                    </Tabs.Trigger>
+                  );
+                })}
+              </Tabs.List>
+
+              {PERIODS.map(period => (
+                <Tabs.Content key={period} value={period} pt={3} px={0}>
+                  <GoalPeriodList
+                    periodKey={period}
+                    goals={getGoals(period)}
+                    onChange={arr => handlePeriodChange(period, arr)}
+                    errors={errors}
+                    sportsList={sportsList}
+                  />
+                </Tabs.Content>
+              ))}
+            </Tabs.Root>
+
+            {/* Validation error summary */}
+            {hasConfigErrors && (
+              <Box
+                p={3}
+                bg={{ base: '#f8d7da', _dark: '#7f1d1d' }}
+                border="1px solid"
+                borderColor={{ base: '#f5c6cb', _dark: '#991b1b' }}
+                borderRadius="md"
+              >
+                <Text fontSize="sm" color={{ base: '#721c24', _dark: '#fca5a5' }}>
+                  Please fix the validation errors above before saving.
+                </Text>
+              </Box>
+            )}
+          </VStack>
+        </Box>
+
+        {/* Footer */}
+        <Flex
+          justify="flex-end"
+          gap={3}
+          px={6}
+          py={4}
+          bg="panelBg"
+          borderTop="1px solid"
+          borderColor="border"
+        >
+          <Button onClick={onClose} variant="outline" colorPalette="gray">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            bg="primary"
+            color="white"
+            _hover={{ bg: 'primaryHover' }}
+          >
+            Save Changes
+          </Button>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default TrainingGoalsConfigModal;

--- a/src/components/widgets/WidgetFormModal.jsx
+++ b/src/components/widgets/WidgetFormModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Flex, Box, Heading, VStack, Button, Field, Input, Textarea, Checkbox } from '@chakra-ui/react';
+import { Flex, Box, Heading, VStack, Button, Field, Input, Textarea, Checkbox, NativeSelectRoot, NativeSelectField, Text } from '@chakra-ui/react';
 import { MdAutoFixHigh } from 'react-icons/md';
 
 /**
@@ -106,16 +106,31 @@ const yamlToJson = (yamlText) => {
 /**
  * WidgetFormModal - Modal for adding/editing widget definitions
  */
-const WidgetFormModal = ({ 
-  isOpen, 
+const WidgetFormModal = ({
+  isOpen,
   mode = 'add', // 'add' or 'edit'
-  formData, 
-  onChange, 
-  onSubmit, 
-  onClose, 
-  error 
+  formData,
+  onChange,
+  onSubmit,
+  onClose,
+  error,
+  widgetDefinitions = []
 }) => {
   const [convertError, setConvertError] = useState('');
+
+  const multiUseWidgets = widgetDefinitions.filter(w => w.allowMultiple);
+
+  const handlePreFill = (widgetName) => {
+    const source = multiUseWidgets.find(w => w.name === widgetName);
+    if (!source) return;
+    onChange('name', source.name);
+    onChange('allowMultiple', source.allowMultiple);
+    onChange('hasConfig', source.hasConfig);
+    onChange('configTemplate', source.configTemplate || '');
+    onChange('defaultConfig', source.defaultConfig ? JSON.stringify(source.defaultConfig, null, 2) : '');
+    onChange('displayName', '');
+    onChange('description', '');
+  };
 
   if (!isOpen) return null;
 
@@ -207,6 +222,37 @@ const WidgetFormModal = ({
                 disabled={mode === 'edit'}
               />
             </Field.Root>
+
+            {mode === 'add' && multiUseWidgets.length > 0 && (
+              <Box>
+                <Text fontSize="xs" color="textMuted" mb={1}>
+                  Or pre-fill from an existing multi-use widget:
+                </Text>
+                <NativeSelectRoot size="sm">
+                  <NativeSelectField
+                    value=""
+                    onChange={e => {
+                      if (e.target.value) handlePreFill(e.target.value);
+                      e.target.value = '';
+                    }}
+                    bg="inputBg"
+                  >
+                    <option value="" disabled>Select widget to pre-fill...</option>
+                    {multiUseWidgets.map(w => (
+                      <option key={w.name} value={w.name}>{w.displayName} ({w.name})</option>
+                    ))}
+                  </NativeSelectField>
+                </NativeSelectRoot>
+              </Box>
+            )}
+
+            {mode === 'add' && formData.name === 'trainingGoals' && (
+              <Box p={2} bg="infoBg" border="1px solid" borderColor="infoBorder" borderRadius="md">
+                <Text fontSize="xs" color="infoText">
+                  After adding, click the pencil icon on this widget to configure its goals using the visual editor.
+                </Text>
+              </Box>
+            )}
 
             <Field.Root>
               <Field.Label color="text">Display Name*</Field.Label>

--- a/src/components/widgets/WidgetListItem.jsx
+++ b/src/components/widgets/WidgetListItem.jsx
@@ -20,7 +20,7 @@ const WidgetListItem = ({ widget, isExpanded, onToggle, onEdit, onDelete }) => {
         bg="panelBg"
       >
         <Button
-          onClick={() => onToggle(widget.name)}
+          onClick={onToggle}
           variant="ghost"
           flex={1}
           justifyContent="flex-start"
@@ -51,9 +51,9 @@ const WidgetListItem = ({ widget, isExpanded, onToggle, onEdit, onDelete }) => {
         </Button>
         <HStack gap={1} px={2}>
           <IconButton
-            onClick={() => onEdit(widget)}
-            title="Edit widget definition"
-            aria-label="Edit widget"
+            onClick={onEdit}
+            title={widget.name === 'trainingGoals' ? 'Configure Training Goals' : 'Edit widget definition'}
+            aria-label={widget.name === 'trainingGoals' ? 'Configure Training Goals' : 'Edit widget'}
             size="sm"
             variant="ghost"
             colorPalette="gray"
@@ -61,7 +61,7 @@ const WidgetListItem = ({ widget, isExpanded, onToggle, onEdit, onDelete }) => {
             <Icon><MdEdit /></Icon>
           </IconButton>
           <IconButton
-            onClick={() => onDelete(widget.name)}
+            onClick={onDelete}
             title="Delete widget definition"
             aria-label="Delete widget"
             size="sm"

--- a/src/components/widgets/training-goals/GoalPeriodList.jsx
+++ b/src/components/widgets/training-goals/GoalPeriodList.jsx
@@ -1,0 +1,128 @@
+import React, { useState, useCallback } from 'react';
+import { Box, VStack, Text, Button, Icon } from '@chakra-ui/react';
+import { MdAdd } from 'react-icons/md';
+import TrainingGoalEntryEditor from './TrainingGoalEntryEditor';
+
+const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1);
+
+const DEFAULT_GOAL = {
+  label: '',
+  enabled: true,
+  type: 'distance',
+  unit: 'km',
+  goal: 0,
+  sportTypesToInclude: [],
+};
+
+const GoalPeriodList = ({ periodKey, goals = [], onChange, errors = {}, sportsList = {} }) => {
+  const [expandedItems, setExpandedItems] = useState({});
+
+  const toggleExpand = (index) => {
+    setExpandedItems(prev => ({ ...prev, [index]: !prev[index] }));
+  };
+
+  const handleAdd = useCallback(() => {
+    const newGoal = { ...DEFAULT_GOAL };
+    onChange([...goals, newGoal]);
+    setExpandedItems(prev => ({ ...prev, [goals.length]: true }));
+  }, [goals, onChange]);
+
+  const handleRemove = useCallback((index) => {
+    onChange(goals.filter((_, i) => i !== index));
+    setExpandedItems(prev => {
+      const next = {};
+      Object.keys(prev).forEach(key => {
+        const k = parseInt(key);
+        if (k < index) next[k] = prev[key];
+        else if (k > index) next[k - 1] = prev[key];
+      });
+      return next;
+    });
+  }, [goals, onChange]);
+
+  const handleUpdate = useCallback((index, updatedGoal) => {
+    const updated = goals.map((g, i) => i === index ? updatedGoal : g);
+    onChange(updated);
+  }, [goals, onChange]);
+
+  const handleMoveUp = useCallback((index) => {
+    if (index === 0) return;
+    const updated = [...goals];
+    [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
+    onChange(updated);
+    setExpandedItems(prev => {
+      const next = { ...prev };
+      const tmp = next[index - 1];
+      next[index - 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }, [goals, onChange]);
+
+  const handleMoveDown = useCallback((index) => {
+    if (index >= goals.length - 1) return;
+    const updated = [...goals];
+    [updated[index], updated[index + 1]] = [updated[index + 1], updated[index]];
+    onChange(updated);
+    setExpandedItems(prev => {
+      const next = { ...prev };
+      const tmp = next[index + 1];
+      next[index + 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }, [goals, onChange]);
+
+  const getEntryErrors = (index) => {
+    const prefix = `${periodKey}[${index}].`;
+    const entryErrors = {};
+    Object.entries(errors).forEach(([key, val]) => {
+      if (key.startsWith(prefix)) entryErrors[key.slice(prefix.length)] = val;
+    });
+    return entryErrors;
+  };
+
+  return (
+    <VStack align="stretch" gap={2}>
+      {goals.length === 0 ? (
+        <Box
+          p={6}
+          textAlign="center"
+          bg="panelBg"
+          borderRadius="md"
+          border="2px dashed"
+          borderColor="border"
+        >
+          <Text fontSize="sm" color="textMuted">
+            No {periodKey} goals yet. Click &ldquo;Add {capitalize(periodKey)} Goal&rdquo; to get started.
+          </Text>
+        </Box>
+      ) : (
+        goals.map((goal, index) => (
+          <TrainingGoalEntryEditor
+            key={index}
+            goal={goal}
+            index={index}
+            periodKey={periodKey}
+            isExpanded={expandedItems[index] || false}
+            onToggleExpand={() => toggleExpand(index)}
+            onUpdate={handleUpdate}
+            onRemove={() => handleRemove(index)}
+            onMoveUp={() => handleMoveUp(index)}
+            onMoveDown={() => handleMoveDown(index)}
+            canMoveUp={index > 0}
+            canMoveDown={index < goals.length - 1}
+            errors={getEntryErrors(index)}
+            sportsList={sportsList}
+          />
+        ))
+      )}
+      <Button onClick={handleAdd} size="sm" variant="outline" width="full" mt={1}>
+        <Icon><MdAdd /></Icon>
+        Add {capitalize(periodKey)} Goal
+      </Button>
+    </VStack>
+  );
+};
+
+export default GoalPeriodList;

--- a/src/components/widgets/training-goals/TrainingGoalEntryEditor.jsx
+++ b/src/components/widgets/training-goals/TrainingGoalEntryEditor.jsx
@@ -1,0 +1,291 @@
+import React from 'react';
+import {
+  Box, Flex, HStack, VStack, Text, Field, Input, Switch,
+  Checkbox, Badge, IconButton, Icon, NativeSelectRoot, NativeSelectField
+} from '@chakra-ui/react';
+import { MdExpandMore, MdChevronRight, MdArrowUpward, MdArrowDownward, MdDelete } from 'react-icons/md';
+import SportTypeMultiSelect from '../../../../app/(config)/_components/appearance/SportTypeMultiSelect';
+import {
+  GOAL_TYPES, UNIT_TYPES, UNIT_NOT_APPLICABLE,
+  GOAL_TYPE_LABELS, UNIT_LABELS
+} from '../../../utils/trainingGoalsValidation';
+
+const TYPE_COLORS = {
+  distance: 'blue',
+  elevation: 'green',
+  movingTime: 'purple',
+  numberOfActivities: 'orange',
+  calories: 'red',
+};
+
+const TrainingGoalEntryEditor = ({
+  goal,
+  index,
+  periodKey,
+  isExpanded,
+  onToggleExpand,
+  onUpdate,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
+  errors = {},
+  sportsList = {},
+}) => {
+  const handleFieldUpdate = (field, value) => {
+    onUpdate(index, { ...goal, [field]: value });
+  };
+
+  const handleTypeChange = (newType) => {
+    const update = { ...goal, type: newType };
+    if (UNIT_NOT_APPLICABLE.includes(newType)) {
+      delete update.unit;
+    } else if (!update.unit) {
+      update.unit = 'km';
+    }
+    onUpdate(index, update);
+  };
+
+  const handleDateRangeToggle = (checked) => {
+    if (checked) {
+      handleFieldUpdate('restrictToDateRange', { from: '', to: '' });
+    } else {
+      const updated = { ...goal };
+      delete updated.restrictToDateRange;
+      onUpdate(index, updated);
+    }
+  };
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const showUnit = goal.type && !UNIT_NOT_APPLICABLE.includes(goal.type);
+
+  return (
+    <Box
+      border="1px solid"
+      borderColor={hasErrors ? 'red.500' : 'border'}
+      borderRadius="md"
+      overflow="hidden"
+    >
+      {/* Header */}
+      <Flex
+        bg="panelBg"
+        px={3}
+        py={2}
+        align="center"
+        gap={2}
+        cursor="pointer"
+        onClick={onToggleExpand}
+        _hover={{ bg: { base: '#e9ecef', _dark: '#334155' } }}
+      >
+        <Icon fontSize="lg" color="textMuted" flexShrink={0}>
+          {isExpanded ? <MdExpandMore /> : <MdChevronRight />}
+        </Icon>
+        <Text flex={1} fontWeight="600" fontSize="sm" color="text" noOfLines={1}>
+          {goal.label || `Goal ${index + 1}`}
+        </Text>
+        {goal.type && (
+          <Badge colorPalette={TYPE_COLORS[goal.type] || 'gray'} size="sm" flexShrink={0}>
+            {GOAL_TYPE_LABELS[goal.type] || goal.type}
+          </Badge>
+        )}
+        <Badge
+          colorPalette={goal.enabled !== false ? 'green' : 'orange'}
+          variant="subtle"
+          size="sm"
+          flexShrink={0}
+        >
+          {goal.enabled !== false ? 'Enabled' : 'Disabled'}
+        </Badge>
+        <HStack gap={0.5} onClick={e => e.stopPropagation()} flexShrink={0}>
+          <IconButton
+            size="xs"
+            variant="ghost"
+            disabled={!canMoveUp}
+            onClick={onMoveUp}
+            aria-label="Move up"
+          >
+            <Icon><MdArrowUpward /></Icon>
+          </IconButton>
+          <IconButton
+            size="xs"
+            variant="ghost"
+            disabled={!canMoveDown}
+            onClick={onMoveDown}
+            aria-label="Move down"
+          >
+            <Icon><MdArrowDownward /></Icon>
+          </IconButton>
+          <IconButton
+            size="xs"
+            variant="ghost"
+            colorPalette="red"
+            onClick={onRemove}
+            aria-label="Remove goal"
+          >
+            <Icon><MdDelete /></Icon>
+          </IconButton>
+        </HStack>
+      </Flex>
+
+      {/* Expanded body */}
+      {isExpanded && (
+        <Box p={4} bg="cardBg" borderTop="1px solid" borderColor="border">
+          <VStack align="stretch" gap={4}>
+            {/* Label + Enabled toggle */}
+            <Flex gap={3} align="flex-end">
+              <Field.Root flex={1} invalid={!!errors.label}>
+                <Field.Label color="text" fontSize="sm">Label*</Field.Label>
+                <Input
+                  placeholder="e.g. Cycling"
+                  value={goal.label || ''}
+                  onChange={e => handleFieldUpdate('label', e.target.value)}
+                  bg="inputBg"
+                  size="sm"
+                />
+                {errors.label && <Field.ErrorText>{errors.label}</Field.ErrorText>}
+              </Field.Root>
+              <Box pb={1}>
+                <Switch.Root
+                  checked={goal.enabled !== false}
+                  onCheckedChange={e => handleFieldUpdate('enabled', e.checked)}
+                  colorPalette="green"
+                >
+                  <Switch.HiddenInput />
+                  <Switch.Control>
+                    <Switch.Thumb />
+                  </Switch.Control>
+                  <Switch.Label fontSize="sm" color="text">Enabled</Switch.Label>
+                </Switch.Root>
+              </Box>
+            </Flex>
+
+            {/* Type + Unit */}
+            <Flex gap={3}>
+              <Field.Root flex={1} invalid={!!errors.type}>
+                <Field.Label color="text" fontSize="sm">Goal Type*</Field.Label>
+                <NativeSelectRoot size="sm">
+                  <NativeSelectField
+                    value={goal.type || ''}
+                    onChange={e => handleTypeChange(e.target.value)}
+                    bg="inputBg"
+                  >
+                    <option value="" disabled>Select type...</option>
+                    {GOAL_TYPES.map(t => (
+                      <option key={t} value={t}>{GOAL_TYPE_LABELS[t]}</option>
+                    ))}
+                  </NativeSelectField>
+                </NativeSelectRoot>
+                {errors.type && <Field.ErrorText>{errors.type}</Field.ErrorText>}
+              </Field.Root>
+
+              {showUnit && (
+                <Field.Root flex={1} invalid={!!errors.unit}>
+                  <Field.Label color="text" fontSize="sm">Unit*</Field.Label>
+                  <NativeSelectRoot size="sm">
+                    <NativeSelectField
+                      value={goal.unit || ''}
+                      onChange={e => handleFieldUpdate('unit', e.target.value)}
+                      bg="inputBg"
+                    >
+                      <option value="" disabled>Select unit...</option>
+                      {UNIT_TYPES.map(u => (
+                        <option key={u} value={u}>{UNIT_LABELS[u]}</option>
+                      ))}
+                    </NativeSelectField>
+                  </NativeSelectRoot>
+                  {errors.unit && <Field.ErrorText>{errors.unit}</Field.ErrorText>}
+                </Field.Root>
+              )}
+            </Flex>
+
+            {/* Goal value */}
+            <Field.Root invalid={!!errors.goal}>
+              <Field.Label color="text" fontSize="sm">Goal Value*</Field.Label>
+              <Input
+                type="number"
+                min={0}
+                step={showUnit && ['km', 'mi', 'm', 'ft'].includes(goal.unit) ? 0.1 : 1}
+                placeholder="e.g. 200"
+                value={goal.goal === 0 ? '0' : (goal.goal || '')}
+                onChange={e => handleFieldUpdate('goal', e.target.value === '' ? '' : Number(e.target.value))}
+                bg="inputBg"
+                size="sm"
+              />
+              {errors.goal && <Field.ErrorText>{errors.goal}</Field.ErrorText>}
+            </Field.Root>
+
+            {/* Sport types */}
+            {Object.keys(sportsList).length > 0 && (
+              <Box>
+                <Text fontSize="sm" fontWeight="medium" color="text" mb={2}>Sport Types to Include</Text>
+                <SportTypeMultiSelect
+                  fieldName="sportTypesToInclude"
+                  fieldSchema={{ title: 'Sport Types to Include', description: 'Count only these sport types toward the goal' }}
+                  fieldPath={`${periodKey}[${index}].sportTypesToInclude`}
+                  value={goal.sportTypesToInclude || []}
+                  onChange={(_, newArr) => handleFieldUpdate('sportTypesToInclude', newArr)}
+                  sportsList={sportsList}
+                  subsectionKey={`${periodKey}-${index}`}
+                />
+              </Box>
+            )}
+
+            {/* Date range restriction */}
+            <Box>
+              <Checkbox.Root
+                checked={!!goal.restrictToDateRange}
+                onCheckedChange={e => handleDateRangeToggle(e.checked)}
+                mb={goal.restrictToDateRange ? 3 : 0}
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+                <Checkbox.Label fontSize="sm" color="text">Restrict to date range (optional)</Checkbox.Label>
+              </Checkbox.Root>
+
+              {goal.restrictToDateRange && (
+                <Flex gap={3} mt={2}>
+                  <Field.Root flex={1} invalid={!!errors['restrictToDateRange.from']}>
+                    <Field.Label color="text" fontSize="sm">From</Field.Label>
+                    <Input
+                      type="date"
+                      value={goal.restrictToDateRange.from || ''}
+                      onChange={e => handleFieldUpdate('restrictToDateRange', {
+                        ...goal.restrictToDateRange,
+                        from: e.target.value
+                      })}
+                      bg="inputBg"
+                      size="sm"
+                    />
+                    {errors['restrictToDateRange.from'] && (
+                      <Field.ErrorText>{errors['restrictToDateRange.from']}</Field.ErrorText>
+                    )}
+                  </Field.Root>
+                  <Field.Root flex={1} invalid={!!errors['restrictToDateRange.to']}>
+                    <Field.Label color="text" fontSize="sm">To</Field.Label>
+                    <Input
+                      type="date"
+                      value={goal.restrictToDateRange.to || ''}
+                      min={goal.restrictToDateRange.from || undefined}
+                      onChange={e => handleFieldUpdate('restrictToDateRange', {
+                        ...goal.restrictToDateRange,
+                        to: e.target.value
+                      })}
+                      bg="inputBg"
+                      size="sm"
+                    />
+                    {errors['restrictToDateRange.to'] && (
+                      <Field.ErrorText>{errors['restrictToDateRange.to']}</Field.ErrorText>
+                    )}
+                  </Field.Root>
+                </Flex>
+              )}
+            </Box>
+          </VStack>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default TrainingGoalEntryEditor;

--- a/src/utils/trainingGoalsValidation.js
+++ b/src/utils/trainingGoalsValidation.js
@@ -1,0 +1,80 @@
+export const GOAL_TYPES = ['distance', 'elevation', 'movingTime', 'numberOfActivities', 'calories'];
+export const UNIT_TYPES = ['km', 'm', 'mi', 'ft', 'hour', 'minute'];
+export const UNIT_NOT_APPLICABLE = ['numberOfActivities', 'calories'];
+export const PERIODS = ['weekly', 'monthly', 'yearly', 'lifetime'];
+
+export const GOAL_TYPE_LABELS = {
+  distance: 'Distance',
+  elevation: 'Elevation',
+  movingTime: 'Moving Time',
+  numberOfActivities: 'Number of Activities',
+  calories: 'Calories',
+};
+
+export const UNIT_LABELS = {
+  km: 'km',
+  m: 'm',
+  mi: 'mi',
+  ft: 'ft',
+  hour: 'hours',
+  minute: 'minutes',
+};
+
+/**
+ * Validates a single training goal entry.
+ * @returns {Object} errors map { fieldName: errorString }
+ */
+export function validateGoalEntry(goal) {
+  const errors = {};
+
+  if (!goal.label || !goal.label.trim()) {
+    errors.label = 'Label is required';
+  }
+
+  if (!goal.type || !GOAL_TYPES.includes(goal.type)) {
+    errors.type = 'Goal type is required';
+  }
+
+  if (goal.type && !UNIT_NOT_APPLICABLE.includes(goal.type)) {
+    if (!goal.unit || !UNIT_TYPES.includes(goal.unit)) {
+      errors.unit = 'Unit is required for this goal type';
+    }
+  }
+
+  if (goal.goal === undefined || goal.goal === null || goal.goal === '') {
+    errors.goal = 'Goal value is required';
+  } else if (typeof goal.goal !== 'number' || isNaN(goal.goal) || goal.goal <= 0) {
+    errors.goal = 'Goal must be a positive number';
+  }
+
+  if (goal.restrictToDateRange) {
+    const { from, to } = goal.restrictToDateRange;
+    if (!from) errors['restrictToDateRange.from'] = 'Start date is required';
+    if (!to) errors['restrictToDateRange.to'] = 'End date is required';
+    if (from && to && from > to) {
+      errors['restrictToDateRange.from'] = 'Start date must be on or before end date';
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validates the full training goals config object.
+ * @returns {Object} flat errors map { 'weekly[0].label': 'error msg', ... }
+ */
+export function validateTrainingGoalsConfig(goalsConfig) {
+  const allErrors = {};
+  const goals = goalsConfig?.goals || {};
+
+  PERIODS.forEach(period => {
+    (goals[period] || []).forEach((entry, i) => {
+      const entryErrors = validateGoalEntry(entry);
+      Object.entries(entryErrors).forEach(([field, msg]) => {
+        allErrors[`${period}[${i}].${field}`] = msg;
+      });
+    });
+  });
+
+  return allErrors;
+}

--- a/src/utils/widgetDefinitionsManager.js
+++ b/src/utils/widgetDefinitionsManager.js
@@ -44,7 +44,16 @@ function toYAML(definitions) {
       } else {
         result = '\n';
         value.forEach(item => {
-          if (typeof item === 'string') {
+          if (typeof item === 'object' && item !== null) {
+            // Serialize each property of the object as a YAML block sequence entry.
+            // First property uses "- key: val", subsequent properties use "  key: val"
+            // aligned with the text after the dash.
+            Object.entries(item).forEach(([k, v], i) => {
+              const linePrefix = i === 0 ? `${spaces}  - ` : `${spaces}    `;
+              result += `${linePrefix}${k}: `;
+              result += serializeValue(v, indent + 2);
+            });
+          } else if (typeof item === 'string') {
             result += `${spaces}  - "${item}"\n`;
           } else {
             result += `${spaces}  - ${item}\n`;

--- a/src/utils/widgetValidation.js
+++ b/src/utils/widgetValidation.js
@@ -25,15 +25,32 @@ export function validateWidgetForm(formData, existingWidgets, editingName = null
     };
   }
 
-  // Check for duplicate names (skip if editing the same widget)
+  // For allowMultiple widgets, multiple instances with the same name are permitted.
+  // For single-instance widgets, block duplicate names (skip when editing that same widget).
   const isDuplicate = existingWidgets.some(
-    w => w.name === formData.name && w.name !== editingName
+    w => w.name === formData.name && w.name !== editingName && !w.allowMultiple
   );
   if (isDuplicate) {
     return {
       isValid: false,
       error: `A widget with the name "${formData.name}" already exists`
     };
+  }
+
+  // For allowMultiple widgets, display name must be unique among instances with the same name
+  const isAllowMultiple = formData.allowMultiple ||
+    existingWidgets.some(w => w.name === formData.name && w.allowMultiple);
+  if (isAllowMultiple && editingName === null) {
+    const isDuplicateDisplayName = existingWidgets.some(
+      w => w.name === formData.name &&
+        w.displayName.trim().toLowerCase() === formData.displayName.trim().toLowerCase()
+    );
+    if (isDuplicateDisplayName) {
+      return {
+        isValid: false,
+        error: `A "${formData.name}" widget with display name "${formData.displayName}" already exists. Use a unique display name.`
+      };
+    }
   }
 
   return { isValid: true, error: null };


### PR DESCRIPTION
## Summary
- Add purpose-built Training Goals config editor (four-tab modal: Weekly/Monthly/Yearly/Lifetime)
- Add pre-fill pulldown for `allowMultiple` widgets in the Add Widget form
- Add "Sync to defaults" button in Dashboard Layout Editor for config drift detection
- Fix multiple bugs with `allowMultiple` widget infrastructure (delete/expand by index, YAML serialization, config.yaml formatting)

## Changes included
- **Training Goals modal** — each goal entry supports label, enabled toggle, type, unit, goal value, sport type multi-select, and optional date range restriction. Uses `next/dynamic` + native date input to avoid `react-datepicker`/`date-fns` OOM crash.
- **Add Widget pre-fill** — dropdown in Add Widget form lists all `allowMultiple: true` definitions; selecting one pre-fills config fields so user only needs to provide Display Name.
- **Sync to defaults** — Dashboard Layout Editor shows an orange button when a widget's stored config differs from the current definition `defaultConfig`.
- **Nested config display** — `[object Object]` in Dashboard Layout Editor config panel replaced with formatted JSON preview.
- **`allowMultiple` infrastructure fixes** — delete-by-index, expand/collapse-by-index, validator allows same name but enforces unique displayName.
- **YAML fixes** — `widgetDefinitionsManager` no longer produces `[object Object]` for goal entries; `update-section` route no longer collapses complex configs to a JSON one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)