### PR TITLE
fix(training-goals): ensure unit key always present and bump version to 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.9] — 2026-04-29
+
+### Fixed
+
+- **`unit` key always written for non-applicable goal types** — changing a Training Goals goal type to `numberOfActivities` or `calories` now sets `unit: ''` instead of deleting the key, which the Stats for Strava app requires to be present even when not applicable. A belt-and-suspenders guard was also added to `handleFieldUpdate` so any edit to an existing goal with a missing `unit` key injects it automatically.
+- **Training Goals modal normalizes stale goals on open** — if `widget-definitions.yaml` was saved before the above fix (goals missing the `unit` key), opening the Training Goals config modal now normalizes those entries in memory before display, preventing silent data loss on re-save.
+- **"Load definition config" sync now includes missing `unit` key** — `DashboardEditor.handleResetConfigToDefaults` and `handleAddWidget` now run the config through a normalization pass, ensuring `unit: ''` is present for all `numberOfActivities` / `calories` goal entries copied from the widget definition, even if the definition file pre-dates the fix.
+- **Clearer Dashboard Layout Editor labels** — "Sync to defaults" button renamed to **"Load definition config"** with an updated tooltip explaining it replaces the layout config with the widget definition's values. Section headers renamed from "Configuration Schema:" / "Current Values:" to **"Widget Definition Config:"** / **"Layout Config:"** to reduce ambiguity.
+- **Info banner in Dashboard Layout Editor** — a note now appears at the top of the layout editor explaining that config is loaded when the page opens; manually edited `config.yaml` files require a page reload to be reflected.
+
+---
+
 ## [1.2.8] — 2026-04-28
 
 ### Added

--- a/app/utilities/_components/DashboardEditor.jsx
+++ b/app/utilities/_components/DashboardEditor.jsx
@@ -10,6 +10,23 @@ import { useDragAndDrop } from '../../../src/hooks/useDragAndDrop';
 let widgetIdCounter = 0;
 const generateWidgetId = () => `widget-${Date.now()}-${++widgetIdCounter}`;
 
+// Ensure training goal entries always carry a unit key (even '' for non-applicable types).
+// Operates on a deep copy so callers can pass the live definition object safely.
+const UNIT_NOT_APPLICABLE = ['numberOfActivities', 'calories'];
+const GOAL_PERIODS = ['weekly', 'monthly', 'yearly', 'lifetime'];
+function normalizeWidgetConfig(widgetName, rawConfig) {
+  if (widgetName !== 'trainingGoals' || !rawConfig?.goals) return rawConfig;
+  const config = JSON.parse(JSON.stringify(rawConfig));
+  GOAL_PERIODS.forEach(period => {
+    (config.goals[period] || []).forEach(goal => {
+      if (UNIT_NOT_APPLICABLE.includes(goal.type) && goal.unit === undefined) {
+        goal.unit = '';
+      }
+    });
+  });
+  return config;
+}
+
 function DashboardEditor({ dashboardLayout, onClose, onSave }) {
   const [widgetDefinitions, setWidgetDefinitions] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -167,10 +184,11 @@ function DashboardEditor({ dashboardLayout, onClose, onSave }) {
 
   const handleResetConfigToDefaults = useCallback((index) => {
     setLayout(prevLayout => {
-      const def = widgetDefinitions[prevLayout[index].widget];
+      const widgetName = prevLayout[index].widget;
+      const def = widgetDefinitions[widgetName];
       if (!def?.defaultConfig) return prevLayout;
       const newLayout = [...prevLayout];
-      newLayout[index] = { ...newLayout[index], config: JSON.parse(JSON.stringify(def.defaultConfig)) };
+      newLayout[index] = { ...newLayout[index], config: normalizeWidgetConfig(widgetName, def.defaultConfig) };
       return newLayout;
     });
     setIsDirty(true);
@@ -203,7 +221,9 @@ function DashboardEditor({ dashboardLayout, onClose, onSave }) {
     };
 
     if (widgetDef.hasConfig) {
-      newWidget.config = widgetDef.defaultConfig ? { ...widgetDef.defaultConfig } : {};
+      newWidget.config = widgetDef.defaultConfig
+        ? normalizeWidgetConfig(widgetName, widgetDef.defaultConfig)
+        : {};
     }
 
     setLayout(prevLayout => [...prevLayout, newWidget]);
@@ -282,6 +302,12 @@ function DashboardEditor({ dashboardLayout, onClose, onSave }) {
               p={{ base: 3, sm: 4 }}
               minH="300px"
             >
+              <Box p={2} bg="infoBg" border="1px solid" borderColor="infoBorder" borderRadius="md">
+                <Text fontSize="xs" color="infoText">
+                  Layout configuration is loaded when this page opens. If you have manually edited{' '}
+                  <Text as="span" fontFamily="mono">config.yaml</Text>, reload the page to see those changes here.
+                </Text>
+              </Box>
               {!layout || layout.length === 0 ? (
                 <Box textAlign="center" py={{ base: 8, sm: 12 }} px={4} color="textMuted">
                   <Box display="flex" justifyContent="center" mb={4}>

--- a/app/utilities/_components/dashboard/DashboardWidgetItem.jsx
+++ b/app/utilities/_components/dashboard/DashboardWidgetItem.jsx
@@ -209,9 +209,9 @@ const DashboardWidgetItem = ({
                     variant="outline"
                     colorPalette="orange"
                     onClick={() => onResetToDefaults(index)}
-                    title="This widget's config differs from the current widget definition defaults. Click to sync."
+                    title="This widget's layout config differs from the widget definition. Click to replace layout config with the definition's values."
                   >
-                    <MdSync /> Sync to defaults
+                    <MdSync /> Load definition config
                   </Button>
                 )}
               </Flex>
@@ -222,7 +222,7 @@ const DashboardWidgetItem = ({
                   {widgetDef && (widgetDef.configTemplate || widgetDef.defaultConfig) && (
                     <Box mb={3} pb={3} borderBottomWidth="1px" borderColor="border">
                       <Text fontSize="xs" fontWeight="600" color="textSecondary" mb={2}>
-                        Configuration Schema:
+                        Widget Definition Config:
                       </Text>
                       <Box
                         as="pre"
@@ -243,7 +243,7 @@ const DashboardWidgetItem = ({
                   )}
                   
                   <Text fontSize="xs" fontWeight="600" color="textSecondary" mb={1}>
-                    Current Values:
+                    Layout Config:
                   </Text>
                   
                   {Object.keys(widget.config).length === 0 ? (

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -487,10 +487,12 @@ The `trainingGoals` widget has a complex `defaultConfig`:
 }
 ```
 
-Each goal entry: `{ label, enabled, type, unit?, goal, sportTypesToInclude, restrictToDateRange? }`
+Each goal entry: `{ label, enabled, type, unit, goal, sportTypesToInclude, restrictToDateRange? }`
 
 Valid `type` values: `distance`, `elevation`, `movingTime`, `numberOfActivities`, `calories`  
-Valid `unit` values: `km`, `m`, `mi`, `ft`, `hour`, `minute` (not applicable for `numberOfActivities`/`calories`)
+Valid `unit` values: `km`, `m`, `mi`, `ft`, `hour`, `minute`
+
+**`unit` key is always required** — for `numberOfActivities` and `calories` types the unit field is hidden in the UI and the value is `''`, but the key must be present in the YAML or the Stats for Strava app build fails. `TrainingGoalEntryEditor.handleTypeChange` sets `unit = ''` (never deletes the key); `handleFieldUpdate` injects `unit: ''` if editing an entry that was saved before this invariant was enforced. `TrainingGoalsConfigModal` normalizes on load for the same reason. `DashboardEditor.normalizeWidgetConfig` applies the same fix when syncing a widget definition into the layout config.
 
 ### Training Goals Editor Components
 

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/src/components/widgets/TrainingGoalsConfigModal.jsx
+++ b/src/components/widgets/TrainingGoalsConfigModal.jsx
@@ -5,7 +5,7 @@ import {
 import { MdClose } from 'react-icons/md';
 import { useSportsList } from '../../contexts/SportsListContext';
 import GoalPeriodList from './training-goals/GoalPeriodList';
-import { validateTrainingGoalsConfig, PERIODS } from '../../utils/trainingGoalsValidation';
+import { validateTrainingGoalsConfig, PERIODS, UNIT_NOT_APPLICABLE } from '../../utils/trainingGoalsValidation';
 
 const PERIOD_LABELS = {
   weekly: 'Weekly',
@@ -22,7 +22,15 @@ const TrainingGoalsConfigModal = ({ isOpen, widget, onSave, onClose }) => {
   const [goalsConfig, setGoalsConfig] = useState(() => {
     const base = { goals: { weekly: [], monthly: [], yearly: [], lifetime: [] } };
     if (!widget?.defaultConfig) return base;
-    return JSON.parse(JSON.stringify(widget.defaultConfig));
+    const cloned = JSON.parse(JSON.stringify(widget.defaultConfig));
+    PERIODS.forEach(period => {
+      (cloned.goals?.[period] || []).forEach(goal => {
+        if (UNIT_NOT_APPLICABLE.includes(goal.type) && goal.unit === undefined) {
+          goal.unit = '';
+        }
+      });
+    });
+    return cloned;
   });
   const [errors, setErrors] = useState({});
   const [submitAttempted, setSubmitAttempted] = useState(false);

--- a/src/components/widgets/training-goals/TrainingGoalEntryEditor.jsx
+++ b/src/components/widgets/training-goals/TrainingGoalEntryEditor.jsx
@@ -34,13 +34,17 @@ const TrainingGoalEntryEditor = ({
   sportsList = {},
 }) => {
   const handleFieldUpdate = (field, value) => {
-    onUpdate(index, { ...goal, [field]: value });
+    const updated = { ...goal, [field]: value };
+    if (UNIT_NOT_APPLICABLE.includes(updated.type) && updated.unit === undefined) {
+      updated.unit = '';
+    }
+    onUpdate(index, updated);
   };
 
   const handleTypeChange = (newType) => {
     const update = { ...goal, type: newType };
     if (UNIT_NOT_APPLICABLE.includes(newType)) {
-      delete update.unit;
+      update.unit = '';
     } else if (!update.unit) {
       update.unit = 'km';
     }


### PR DESCRIPTION
## Summary
- Fix `unit` key being deleted instead of set to `''` for `numberOfActivities`/`calories` goal types
- Normalize missing `unit` keys at every entry point (modal open, field edit, definition sync, widget add)
- Rename confusing "Sync to defaults" button and section labels in Dashboard Layout Editor

## Changes included
- `TrainingGoalEntryEditor`: `handleTypeChange` sets `unit = ''` (not `delete unit`); `handleFieldUpdate` injects `unit: ''` for any edit to an existing UNIT_NOT_APPLICABLE goal
- `TrainingGoalsConfigModal`: normalizes goals on open — fixes stale entries saved before this fix
- `DashboardEditor`: new `normalizeWidgetConfig` helper applied in `handleResetConfigToDefaults` (sync) and `handleAddWidget`; info banner added explaining config staleness
- `DashboardWidgetItem`: "Sync to defaults" → "Load definition config", clearer tooltip, "Configuration Schema:" → "Widget Definition Config:", "Current Values:" → "Layout Config:"
- `CHANGELOG.md`, `docs/DEVELOPER.md`, version bumped to 1.2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)