### PR TITLE
fix(zwift): remove level cap, fix stale cache — v1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.10] — 2026-05-02
+
+### Changed
+
+- **Zwift level cap removed** — the Zwift Level field now accepts any value ≥ 1 with no upper limit, reflecting Zwift's removal of the level 100 cap. Help text and placeholder updated to read "1 or higher".
+- **Validation Settings tab simplified** — the "Maximum Zwift Level" setting has been removed from Settings → Validation since there is no longer a configurable cap. The tab now shows a placeholder for future validation settings.
+- **Config pages always reload from disk on navigation** — all nine configuration pages (General, Athlete, Appearance, Import, Metrics, Gear, Integrations, Scheduling Daemon, Zwift) previously cached section data after the first load and would show stale values if the config file was edited externally. They now re-read from disk on every navigation.
+
+### Fixed
+
+- **Zwift level validation async bug** — `ZwiftConfigEditor` was calling `loadSettings()` without `await`, receiving a Promise instead of the actual settings object and always falling back to the default level cap of 100 regardless of what was configured in Validation Settings. The `maxZwiftLevel` concept has been removed entirely as part of the cap removal.
+
+---
+
 ## [1.2.9] — 2026-04-29
 
 ### Fixed

--- a/app/(config)/_components/ZwiftConfigEditor.jsx
+++ b/app/(config)/_components/ZwiftConfigEditor.jsx
@@ -1,45 +1,34 @@
-import React, { useEffect, useState, useCallback, memo } from 'react';
+import React, { useCallback, memo } from 'react';
 import { Box, Text, Input, Flex, VStack, Heading, Icon } from '@chakra-ui/react';
 import { MdInfo } from 'react-icons/md';
 import BaseConfigEditor from './BaseConfigEditor';
-import { loadSettings } from '../../../src/utils/settingsManager';
 
 /**
  * ZwiftConfigEditor - Handles Zwift integration configuration fields
  * Uses BaseConfigEditor for standard field rendering
  */
-const ZwiftConfigEditor = ({ 
-  initialData, 
-  onSave, 
-  onCancel, 
+const ZwiftConfigEditor = ({
+  initialData,
+  onSave,
+  onCancel,
   isLoading,
-  onDirtyChange 
+  onDirtyChange
 }) => {
-  const [maxZwiftLevel, setMaxZwiftLevel] = useState(100);
-
-  // Load max Zwift level from settings
-  useEffect(() => {
-    queueMicrotask(() => {
-      const settings = loadSettings();
-      setMaxZwiftLevel(settings.validation?.maxZwiftLevel || 100);
-    });
-  }, []);
-
   // Memoize custom validation function to prevent BaseConfigEditor re-renders
   const validateZwiftFields = useCallback((formData, getNestedValue) => {
     const errors = {};
-    
+
     const level = getNestedValue(formData, 'level');
     const racingScore = getNestedValue(formData, 'racingScore');
-    
-    // Validate level range if provided
+
+    // Validate level is at least 1 if provided (Zwift has no upper cap)
     if (level !== null && level !== undefined && level !== '') {
       const levelNum = parseInt(level);
-      if (isNaN(levelNum) || levelNum < 1 || levelNum > maxZwiftLevel) {
-        errors['level'] = `Zwift level must be between 1 and ${maxZwiftLevel}`;
+      if (isNaN(levelNum) || levelNum < 1) {
+        errors['level'] = 'Zwift level must be 1 or higher';
       }
     }
-    
+
     // Validate racing score range if provided
     if (racingScore !== null && racingScore !== undefined && racingScore !== '') {
       const scoreNum = parseInt(racingScore);
@@ -49,7 +38,7 @@ const ZwiftConfigEditor = ({
     }
 
     return errors;
-  }, [maxZwiftLevel]); // Depends on maxZwiftLevel for validation
+  }, []);
 
   return (
     <BaseConfigEditor
@@ -82,25 +71,24 @@ const ZwiftConfigEditor = ({
               <Box>
                 <Flex align="center" gap={2} mb={1}>
                   <Text fontWeight="500">Zwift Level</Text>
-                  <Text 
-                    fontSize="sm" 
-                    color="textMuted" 
+                  <Text
+                    fontSize="sm"
+                    color="textMuted"
                     cursor="help"
-                    title="Your Zwift level (1 - 100). Will be used to render your Zwift badge. Leave empty to disable this feature"
+                    title="Your Zwift level (1 or higher). Will be used to render your Zwift badge. Leave empty to disable this feature"
                   >
                     ⓘ
                   </Text>
                 </Flex>
                 <Text fontSize="sm" color="textMuted" mb={2}>
-                  Your Zwift level (1 - {maxZwiftLevel}). Will be used to render your Zwift badge. Leave empty to disable this feature.
+                  Your Zwift level (1 or higher). Will be used to render your Zwift badge. Leave empty to disable this feature.
                 </Text>
                 <Input
                   type="number"
                   value={levelValue === null || levelValue === undefined ? '' : levelValue}
                   onChange={(e) => handleFieldChange('level', e.target.value === '' ? null : parseInt(e.target.value))}
-                  placeholder={`Enter your Zwift level (1-${maxZwiftLevel})`}
+                  placeholder="Enter your Zwift level (1 or higher)"
                   min="1"
-                  max={maxZwiftLevel}
                   borderColor={errors['level'] ? 'red.500' : 'border'}
                   bg="inputBg"
                 />

--- a/app/(config)/appearance/page.jsx
+++ b/app/(config)/appearance/page.jsx
@@ -16,12 +16,12 @@ export default function AppearancePage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.appearance) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Appearance')
     }
-  }, [sectionToFileMap, sectionData.appearance, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('appearance', data)
   const handleCancel = () => {

--- a/app/(config)/athlete/page.jsx
+++ b/app/(config)/athlete/page.jsx
@@ -16,12 +16,12 @@ export default function AthletePage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.athlete) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Athlete')
     }
-  }, [sectionToFileMap, sectionData.athlete, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('athlete', data)
   const handleCancel = () => {

--- a/app/(config)/daemon/page.jsx
+++ b/app/(config)/daemon/page.jsx
@@ -16,12 +16,12 @@ export default function DaemonPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.daemon) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Scheduling Daemon')
     }
-  }, [sectionToFileMap, sectionData.daemon, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('daemon', data)
   const handleCancel = () => {

--- a/app/(config)/gear/page.jsx
+++ b/app/(config)/gear/page.jsx
@@ -16,12 +16,12 @@ export default function GearPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.gear) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Gear')
     }
-  }, [sectionToFileMap, sectionData.gear, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('gear', data)
   const handleCancel = () => {

--- a/app/(config)/general/page.jsx
+++ b/app/(config)/general/page.jsx
@@ -16,12 +16,12 @@ export default function GeneralPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.general) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('General')
     }
-  }, [sectionToFileMap, sectionData.general, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('general', data)
   const handleCancel = () => {

--- a/app/(config)/import/page.jsx
+++ b/app/(config)/import/page.jsx
@@ -16,12 +16,12 @@ export default function ImportPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.import) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Import')
     }
-  }, [sectionToFileMap, sectionData.import, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('import', data)
   const handleCancel = () => {

--- a/app/(config)/integrations/page.jsx
+++ b/app/(config)/integrations/page.jsx
@@ -16,12 +16,12 @@ export default function IntegrationsPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.integrations) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Integrations')
     }
-  }, [sectionToFileMap, sectionData.integrations, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('integrations', data)
   const handleCancel = () => {

--- a/app/(config)/metrics/page.jsx
+++ b/app/(config)/metrics/page.jsx
@@ -16,12 +16,12 @@ export default function MetricsPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.metrics) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Metrics')
     }
-  }, [sectionToFileMap, sectionData.metrics, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('metrics', data)
   const handleCancel = () => {

--- a/app/(config)/zwift/page.jsx
+++ b/app/(config)/zwift/page.jsx
@@ -16,12 +16,12 @@ export default function ZwiftPage() {
   const { sectionData, saveSectionData, isLoadingSectionData, loadSectionData, sectionToFileMap } = useConfig()
   const { setHasUnsavedChanges, checkAndConfirmNavigation } = useDirtyState()
 
-  // Load section data if not already loaded
+  // Reload on every navigation to pick up external file edits
   useEffect(() => {
-    if (sectionToFileMap.size > 0 && !sectionData.zwift) {
+    if (sectionToFileMap.size > 0) {
       loadSectionData('Zwift')
     }
-  }, [sectionToFileMap, sectionData.zwift, loadSectionData])
+  }, [sectionToFileMap, loadSectionData])
 
   const handleSave = (data) => saveSectionData('zwift', data)
   const handleCancel = () => {

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/src/components/settings/ValidationSettingsModal.jsx
+++ b/src/components/settings/ValidationSettingsModal.jsx
@@ -5,8 +5,6 @@ import {
   Heading,
   Text,
   Button,
-  Field,
-  Input,
   Flex,
   Icon,
 } from '@chakra-ui/react';
@@ -46,19 +44,6 @@ const ValidationSettingsModal = ({ isOpen, onClose, embedded = false }) => {
     onClose();
   };
 
-  const handleChange = (path, value) => {
-    const keys = path.split('.');
-    const newSettings = { ...settings };
-    let current = newSettings;
-    for (let i = 0; i < keys.length - 1; i++) {
-      if (!current[keys[i]]) current[keys[i]] = {};
-      current = current[keys[i]];
-    }
-    current[keys[keys.length - 1]] = value;
-    setSettings(newSettings);
-    setIsDirty(true);
-  };
-
   const handleSave = async () => {
     const success = await saveSettings(settings);
     if (success) {
@@ -80,22 +65,9 @@ const ValidationSettingsModal = ({ isOpen, onClose, embedded = false }) => {
             Configure validation limits that may change in the future. These values affect schema validation when editing configuration files.
           </Text>
 
-          {/* Maximum Zwift Level Setting */}
-          <Field.Root>
-            <Field.Label fontWeight="500" mb={2}>Maximum Zwift Level</Field.Label>
-            <Input
-              type="number"
-              min="1"
-              max="200"
-              value={settings.validation?.maxZwiftLevel || 100}
-              onChange={(e) => handleChange('validation.maxZwiftLevel', parseInt(e.target.value))}
-              bg="inputBg"
-              width={{ base: "100%", sm: "150px" }}
-            />
-            <Field.HelperText color="textMuted" fontSize="sm" mt={1}>
-              The maximum allowed Zwift level. Currently capped at {settings.validation?.maxZwiftLevel || 100}. Zwift may increase this limit in the future.
-            </Field.HelperText>
-          </Field.Root>
+          <Text fontSize="sm" color="textMuted" fontStyle="italic">
+            No validation limits are currently configured.
+          </Text>
         </VStack>
 
         {/* Modal Footer */}
@@ -192,22 +164,9 @@ const ValidationSettingsModal = ({ isOpen, onClose, embedded = false }) => {
             Configure validation limits that may change in the future. These values affect schema validation when editing configuration files.
           </Text>
 
-          {/* Maximum Zwift Level Setting */}
-          <Field.Root>
-            <Field.Label fontWeight="500" mb={2}>Maximum Zwift Level</Field.Label>
-            <Input
-              type="number"
-              min="1"
-              max="200"
-              value={settings.validation?.maxZwiftLevel || 100}
-              onChange={(e) => handleChange('validation.maxZwiftLevel', parseInt(e.target.value))}
-              bg="inputBg"
-              width={{ base: "100%", sm: "150px" }}
-            />
-            <Field.HelperText color="textMuted" fontSize="sm" mt={1}>
-              The maximum allowed Zwift level. Currently capped at {settings.validation?.maxZwiftLevel || 100}. Zwift may increase this limit in the future.
-            </Field.HelperText>
-          </Field.Root>
+          <Text fontSize="sm" color="textMuted" fontStyle="italic">
+            No validation limits are currently configured.
+          </Text>
         </VStack>
 
         {/* Modal Footer */}

--- a/src/utils/settingsManager.js
+++ b/src/utils/settingsManager.js
@@ -78,9 +78,6 @@ const getDefaultSettings = () => ({
     wordWrap: true,
     highlightSearch: true,
   },
-  validation: {
-    maxZwiftLevel: 100, // Maximum Zwift level (can increase in future)
-  }
 });
 
 // Maintain backwards compatibility


### PR DESCRIPTION
## Summary
- Zwift removed its level 100 cap; validation now accepts any level >= 1
- Removed obsolete Maximum Zwift Level setting from Validation Settings tab
- All 9 config pages now re-read from disk on every navigation (fixes stale data after external file edits)

## Changes included
- ZwiftConfigEditor: removed maxZwiftLevel state/effect/async bug; help text updated to "1 or higher"; max input attribute removed
- ValidationSettingsModal: removed Maximum Zwift Level field and unused imports/handlers; replaced with placeholder text
- settingsManager.js: removed validation.maxZwiftLevel default
- All app/(config)/*/page.jsx (9 files): removed load-once guard so each navigation triggers a fresh disk read

🤖 Generated with [Claude Code](https://claude.com/claude-code)