### PR TITLE
feat(appearance): add heatmap initialCenter and initialZoom settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.11] — 2026-05-05
+
+### Added
+
+- **Heatmap initial viewport settings** — two new optional fields in the Appearance → Heatmap section: `initialCenter` (latitude/longitude) and `initialZoom` (1–18). When both are set, the Stats for Strava heatmap opens at that fixed viewport instead of auto-fitting to the user's most active area. The fields must be used together — saving only one produces a validation error.
+- **"Use My Location" button** — clicking this button in the Initial Center row calls the browser Geolocation API and fills both latitude and longitude from the device's current position (rounded to 4 decimal places). A clear error message is shown if geolocation is unavailable or denied.
+- **Zoom level hint text** — helper text below the Initial Zoom input explains the Leaflet zoom scale: 1–5 for continent/country, 6–12 for region/city, 13–18 for street/building detail.
+
+---
+
 ## [1.2.10] — 2026-05-02
 
 ### Changed

--- a/app/(config)/_components/AppearanceConfigEditor.jsx
+++ b/app/(config)/_components/AppearanceConfigEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useMemo, memo, lazy, Suspense } from 'react';
 import { Box, Button, Flex, Text, VStack, HStack, Icon, ColorPicker, Portal, parseColor, Input, Code, Badge, Spinner } from '@chakra-ui/react';
-import { MdInfo, MdWarning, MdDashboard, MdExpandMore, MdChevronRight, MdAdd, MdClose } from 'react-icons/md';
+import { MdInfo, MdWarning, MdDashboard, MdExpandMore, MdChevronRight, MdAdd, MdClose, MdMyLocation } from 'react-icons/md';
 import BaseConfigEditor from './BaseConfigEditor';
 import CountrySelector from '../../_components/fields/CountrySelector';
 const DashboardEditor = lazy(() => import('../../../app/utilities/_components/DashboardEditor'));
@@ -25,6 +25,7 @@ const AppearanceConfigEditor = ({
   const [showDashboardEditor, setShowDashboardEditor] = useState(false);
   const [dashboardJustSaved, setDashboardJustSaved] = useState(false);
   const [dashboardLayout, setDashboardLayout] = useState(initialData?.dashboard?.layout || []);
+  const [geoError, setGeoError] = useState(null);
   const countryChangeHandlerRef = useRef(null);
   const formDataRef = useRef(null);
   const [expandedGroups, setExpandedGroups] = useState({
@@ -537,6 +538,143 @@ const AppearanceConfigEditor = ({
                   
                   {/* enableGreyScale */}
                   {renderBasicField('heatmap.enableGreyScale', fieldSchema.properties.enableGreyScale)}
+
+                  {/* initialCenter */}
+                  {(() => {
+                    const initialCenterValue = getNestedValue(formData, 'heatmap.initialCenter');
+                    const lat = Array.isArray(initialCenterValue) ? initialCenterValue[0] : '';
+                    const lng = Array.isArray(initialCenterValue) ? initialCenterValue[1] : '';
+                    const centerSet = initialCenterValue !== null && initialCenterValue !== undefined;
+
+                    const handleLatChange = (e) => {
+                      const val = e.target.value;
+                      if (val === '') {
+                        handleFieldChange('heatmap.initialCenter', null);
+                      } else {
+                        const parsed = parseFloat(val);
+                        if (!isNaN(parsed)) {
+                          handleFieldChange('heatmap.initialCenter', [parsed, Array.isArray(initialCenterValue) ? initialCenterValue[1] : 0]);
+                        }
+                      }
+                    };
+
+                    const handleLngChange = (e) => {
+                      const val = e.target.value;
+                      if (val === '') {
+                        handleFieldChange('heatmap.initialCenter', null);
+                      } else {
+                        const parsed = parseFloat(val);
+                        if (!isNaN(parsed)) {
+                          handleFieldChange('heatmap.initialCenter', [Array.isArray(initialCenterValue) ? initialCenterValue[0] : 0, parsed]);
+                        }
+                      }
+                    };
+
+                    const handleUseMyLocation = () => {
+                      if (!navigator.geolocation) {
+                        setGeoError('Geolocation is not supported by your browser');
+                        return;
+                      }
+                      navigator.geolocation.getCurrentPosition(
+                        (position) => {
+                          const lat = Math.round(position.coords.latitude * 10000) / 10000;
+                          const lng = Math.round(position.coords.longitude * 10000) / 10000;
+                          handleFieldChange('heatmap.initialCenter', [lat, lng]);
+                          setGeoError(null);
+                        },
+                        () => setGeoError('Unable to retrieve your location')
+                      );
+                    };
+
+                    return (
+                      <Box mb={4}>
+                        <Text fontWeight="500" mb={1}>{fieldSchema.properties.initialCenter.title}</Text>
+                        <Text fontSize="sm" color="textMuted" mb={2}>{fieldSchema.properties.initialCenter.description}</Text>
+                        <Flex gap={2} wrap="wrap" align="center" mb={1}>
+                          <Input
+                            type="number"
+                            placeholder="Latitude (e.g. 51.05)"
+                            value={lat}
+                            onChange={handleLatChange}
+                            step="0.0001"
+                            min="-90"
+                            max="90"
+                            borderColor={errors['heatmap.initialCenter'] ? 'red.500' : 'border'}
+                            flex="1"
+                            minW="160px"
+                          />
+                          <Input
+                            type="number"
+                            placeholder="Longitude (e.g. 3.72)"
+                            value={lng}
+                            onChange={handleLngChange}
+                            step="0.0001"
+                            min="-180"
+                            max="180"
+                            borderColor={errors['heatmap.initialCenter'] ? 'red.500' : 'border'}
+                            flex="1"
+                            minW="160px"
+                          />
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={handleUseMyLocation}
+                            flexShrink={0}
+                          >
+                            <Box as={MdMyLocation} mr={1} /> Use My Location
+                          </Button>
+                          {centerSet && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              colorPalette="red"
+                              onClick={() => {
+                                handleFieldChange('heatmap.initialCenter', null);
+                                handleFieldChange('heatmap.initialZoom', null);
+                              }}
+                              flexShrink={0}
+                            >
+                              <Box as={MdClose} mr={1} /> Clear
+                            </Button>
+                          )}
+                        </Flex>
+                        {geoError && <Text color="red.500" fontSize="sm" mb={1}>{geoError}</Text>}
+                        {errors['heatmap.initialCenter'] && (
+                          <Text color="red.500" fontSize="sm" mt={1}>{errors['heatmap.initialCenter']}</Text>
+                        )}
+                      </Box>
+                    );
+                  })()}
+
+                  {/* initialZoom */}
+                  {(() => {
+                    const initialZoomValue = getNestedValue(formData, 'heatmap.initialZoom');
+                    return (
+                      <Box mb={4}>
+                        <Text fontWeight="500" mb={1}>{fieldSchema.properties.initialZoom.title}</Text>
+                        <Text fontSize="sm" color="textMuted" mb={2}>{fieldSchema.properties.initialZoom.description}</Text>
+                        <Input
+                          type="number"
+                          placeholder="e.g. 12"
+                          value={initialZoomValue ?? ''}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            handleFieldChange('heatmap.initialZoom', val === '' ? null : parseInt(val, 10));
+                          }}
+                          min="1"
+                          max="18"
+                          borderColor={errors['heatmap.initialZoom'] ? 'red.500' : 'border'}
+                          maxW="120px"
+                        />
+                        <Text fontSize="xs" color="textMuted" mt={1}>
+                          1–5: continent/country · 6–12: region/city · 13–18: street/building detail
+                        </Text>
+                        {errors['heatmap.initialZoom'] && (
+                          <Text color="red.500" fontSize="sm" mt={1}>{errors['heatmap.initialZoom']}</Text>
+                        )}
+                      </Box>
+                    );
+                  })()}
                     </Box>
                   )}
                 </Box>

--- a/app/(config)/_components/appearance/useAppearanceConfig.js
+++ b/app/(config)/_components/appearance/useAppearanceConfig.js
@@ -23,6 +23,31 @@ export const useAppearanceConfig = () => {
       errors['photos.defaultEnabledFilters.countryCode'] = 'Must be a 2-letter uppercase ISO2 country code (e.g., US, GB, FR)';
     }
 
+    // Validate initialCenter and initialZoom (must be used together)
+    const initialCenter = getNestedValue(formData, 'heatmap.initialCenter');
+    const initialZoom = getNestedValue(formData, 'heatmap.initialZoom');
+    const centerSet = initialCenter !== null && initialCenter !== undefined;
+    const zoomSet = initialZoom !== null && initialZoom !== undefined;
+
+    if (centerSet) {
+      if (!zoomSet) {
+        errors['heatmap.initialZoom'] = 'Required when Initial Center is set';
+      }
+      if (Array.isArray(initialCenter)) {
+        const lat = initialCenter[0];
+        const lng = initialCenter[1];
+        if (lat < -90 || lat > 90) {
+          errors['heatmap.initialCenter'] = 'Latitude must be between -90 and 90';
+        } else if (lng < -180 || lng > 180) {
+          errors['heatmap.initialCenter'] = 'Longitude must be between -180 and 180';
+        }
+      }
+    }
+
+    if (zoomSet && !centerSet) {
+      errors['heatmap.initialCenter'] = 'Required when Initial Zoom is set';
+    }
+
     return errors;
   };
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -699,6 +699,19 @@ HeatmapTileLayerField.propTypes = {
 - Supports array of URLs
 - Add/remove layer functionality
 
+#### Heatmap initialCenter / initialZoom fields
+
+Two optional fields rendered inline in `AppearanceConfigEditor.jsx` after `enableGreyScale`.
+
+- **initialCenter** — two `<Input type="number">` fields (latitude −90/90, longitude −180/180) rendered side-by-side, plus a "Use My Location" button (browser Geolocation API) and a "Clear" button (resets both fields and `initialZoom` to null).
+- **initialZoom** — single `<Input type="number">` (1–18) with a zoom-level hint beneath it.
+
+**Cross-field validation** (in `useAppearanceConfig.js` → `validateAppearanceFields`):
+- If `initialCenter` is set, `initialZoom` is required (and vice versa).
+- Latitude must be in range −90 to 90; longitude in range −180 to 180.
+
+**Schema**: `src/schemas/configSchemas.js` → `appearanceSchema.properties.heatmap.properties.initialCenter` / `initialZoom`. Neither field is in `required` — both are optional when omitted entirely.
+
 #### PhotosDefaultFiltersField
 
 Combined field for default photo filters (sport types and country).

--- a/helper/package.json
+++ b/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-helper",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Privileged helper container that executes validated commands inside the statistics-for-strava container",
   "type": "module",
   "main": "server.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stats-for-strava-config-tool",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stats-for-strava-config-tool",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stats-for-strava-config-tool",
   "private": true,
-  "version": "1.2.10",
+  "version": "1.2.11",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/public/config-merged.yaml
+++ b/public/config-merged.yaml
@@ -270,6 +270,8 @@ appearance:
     polylineColor: "#fc6719"
     tileLayerUrl: https://tile.openstreetmap.org/{z}/{x}/{y}.png
     enableGreyScale: true
+    initialCenter: null
+    initialZoom: null
 
 #---------------------------------#
 # Photos Configuration Settings

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -209,6 +209,16 @@ appearance:
     #  - 'https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}.png'
     # Enables or disables grayscale styling on the heatmap.
     enableGreyScale: true
+    # Optional, sets the initial center point of the heatmap as [latitude, longitude].
+    # When set together with initialZoom, the map will use this fixed viewport instead of auto-fitting to your most active area.
+    # 🔥 PRO tip: You can easily get the latitude and longitude by navigating to a location in Google Maps. The coordinates are shown in the URL.
+    # Leave empty to auto-fit.
+    initialCenter: null
+    # initialCenter: [51.05, 3.72]
+    # Optional, sets the initial zoom level of the heatmap (1-18, where 1 is fully zoomed out and 18 is street-level).
+    # Must be used together with initialCenter.
+    initialZoom: null
+    # initialZoom: 12
   photos:
     # Optional, an array of sport types for which photos should be hidden on the photos page. 
     # They will not be rendered, and they won't show up in the filters. 

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-cmd-runner",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Sidecar container for running Symfony console commands with real-time streaming",
   "type": "module",
   "main": "server.js",

--- a/src/schemas/configSchemas.js
+++ b/src/schemas/configSchemas.js
@@ -370,6 +370,25 @@ export const appearanceSchema = {
           title: "Enable Grayscale",
           description: "Apply grayscale styling to the heatmap",
           default: true
+        },
+        initialCenter: {
+          type: ["array", "null"],
+          title: "Initial Center",
+          description: "Optional fixed center point [latitude, longitude] for the heatmap. When set together with initialZoom, the map will use this fixed viewport instead of auto-fitting to your most active area. Leave empty to auto-fit.",
+          items: { type: "number" },
+          minItems: 2,
+          maxItems: 2,
+          default: null,
+          examples: [[51.05, 3.72], null]
+        },
+        initialZoom: {
+          type: ["integer", "null"],
+          title: "Initial Zoom",
+          description: "Initial zoom level for the heatmap (1–18, where 1 is fully zoomed out and 18 is street-level). Must be used together with initialCenter.",
+          minimum: 1,
+          maximum: 18,
+          default: null,
+          examples: [12, null]
         }
       },
       required: ["polylineColor", "tileLayerUrl", "enableGreyScale"]


### PR DESCRIPTION
## Summary
- Bump version to 1.2.11
- Add initialCenter and initialZoom optional settings to the Appearance Heatmap config section

## Changes included
- New schema fields: initialCenter ([lat, lng] array or null) and initialZoom (integer 1-18 or null) added to appearanceSchema.heatmap in configSchemas.js
- Cross-field validation: both fields must be set together; latitude -90/90 and longitude -180/180 range enforced in useAppearanceConfig.js
- New UI in Appearance Heatmap: lat/lng number inputs side-by-side, Use My Location geolocation button fills coords to 4 decimal places, Clear button resets both fields, zoom input with Leaflet zoom-level hint text
- Config YAML updated: public/config.yaml and public/config-merged.yaml include initialCenter: null and initialZoom: null with full developer comments

Generated with Claude Code (https://claude.com/claude-code)